### PR TITLE
Add support for shading objects in content generation and redaction

### DIFF
--- a/core/fpdfapi/edit/cpdf_pagecontentgenerator.cpp
+++ b/core/fpdfapi/edit/cpdf_pagecontentgenerator.cpp
@@ -30,6 +30,8 @@
 #include "core/fpdfapi/page/cpdf_path.h"
 #include "core/fpdfapi/page/cpdf_pathobject.h"
 #include "core/fpdfapi/page/cpdf_pattern.h"
+#include "core/fpdfapi/page/cpdf_shadingobject.h"
+#include "core/fpdfapi/page/cpdf_shadingpattern.h"
 #include "core/fpdfapi/page/cpdf_textobject.h"
 #include "core/fpdfapi/page/cpdf_color.h"
 #include "core/fpdfapi/page/cpdf_colorspace.h"
@@ -53,9 +55,7 @@
 
 namespace {
 
-// TODO(thestig): Remove/restore other unused resource types:
-// - Shading
-constexpr const char* kResourceKeys[] = {"ExtGState", "Font", "XObject", "ColorSpace", "Pattern"};
+constexpr const char* kResourceKeys[] = {"ExtGState", "Font", "XObject", "ColorSpace", "Pattern", "Shading"};
 
 // Key: The resource type.
 // Value: The resource names of a given type.
@@ -127,6 +127,7 @@ void RecordPageObjectResourceUsage(const CPDF_PageObject* page_object,
       case CPDF_PageObject::Type::kPath:
         break;
       case CPDF_PageObject::Type::kShading:
+        seen_resources["Shading"].insert(resource_name);
         break;
     }
   }
@@ -851,6 +852,8 @@ void CPDF_PageContentGenerator::ProcessPageObject(fxcrt::ostringstream* buf,
     ProcessPath(buf, pPathObj);
   } else if (CPDF_TextObject* pTextObj = pPageObj->AsText()) {
     ProcessText(buf, pTextObj);
+  } else if (CPDF_ShadingObject* pShadingObj = pPageObj->AsShading()) {
+    ProcessShading(buf, pShadingObj);
   }
   pPageObj->SetDirty(false);
 }
@@ -924,6 +927,34 @@ void CPDF_PageContentGenerator::ProcessForm(fxcrt::ostringstream* buf,
   }
 
   *buf << "/" << PDF_NameEncode(name) << " Do";
+  EndProcessGraphics(*buf);
+}
+
+void CPDF_PageContentGenerator::ProcessShading(fxcrt::ostringstream* buf,
+                                               CPDF_ShadingObject* pShadingObj) {
+  const CPDF_ShadingPattern* pattern = pShadingObj->pattern();
+  if (!pattern)
+    return;
+
+  // Get the underlying shading object (dictionary or stream)
+  RetainPtr<const CPDF_Object> shading_obj = pattern->GetShadingObject();
+  if (!shading_obj)
+    return;
+
+  ProcessGraphics(buf, pShadingObj);
+
+  // Apply the shading object's transformation matrix
+  const CFX_Matrix& matrix = pShadingObj->matrix();
+  if (!matrix.IsIdentity()) {
+    WriteMatrix(*buf, matrix) << " cm ";
+  }
+
+  // Realize the shading as a resource
+  ByteString name = RealizeResource(shading_obj.Get(), "Shading");
+  pShadingObj->SetResourceName(name);
+
+  // Emit the shading operator with BX/EX compatibility markers
+  *buf << "BX /" << PDF_NameEncode(name) << " sh EX";
   EndProcessGraphics(*buf);
 }
 
@@ -1066,6 +1097,19 @@ void CPDF_PageContentGenerator::ProcessGraphics(fxcrt::ostringstream* buf,
     }
   }
 
+  // Emit any existing graphics state resources first (these may contain
+  // properties beyond alpha/blend like soft masks, overprint modes, etc.)
+  pdfium::span<const ByteString> existing_gs_names =
+      pPageObj->GetGraphicsResourceNames();
+  if (!existing_gs_names.empty()) {
+    // Emit all existing ExtGState resources with their original names
+    for (const ByteString& gs_name : existing_gs_names) {
+      *buf << "/" << PDF_NameEncode(gs_name) << " gs ";
+    }
+    return;
+  }
+
+  // No existing graphics state - check if we need to create one for alpha/blend
   GraphicsData graphD;
   graphD.fillAlpha = pPageObj->general_state().GetFillAlpha();
   graphD.strokeAlpha = pPageObj->general_state().GetStrokeAlpha();

--- a/core/fpdfapi/edit/cpdf_pagecontentgenerator.h
+++ b/core/fpdfapi/edit/cpdf_pagecontentgenerator.h
@@ -25,6 +25,7 @@ class CPDF_PageObject;
 class CPDF_PageObjectHolder;
 class CPDF_Path;
 class CPDF_PathObject;
+class CPDF_ShadingObject;
 class CPDF_TextObject;
 class CPDF_Color; 
 class CPDF_ColorSpace;
@@ -46,6 +47,7 @@ class CPDF_PageContentGenerator {
   void ProcessPath(fxcrt::ostringstream* buf, CPDF_PathObject* pPathObj);
   void ProcessForm(fxcrt::ostringstream* buf, CPDF_FormObject* pFormObj);
   void ProcessImage(fxcrt::ostringstream* buf, CPDF_ImageObject* pImageObj);
+  void ProcessShading(fxcrt::ostringstream* buf, CPDF_ShadingObject* pShadingObj);
   void ProcessGraphics(fxcrt::ostringstream* buf, CPDF_PageObject* pPageObj);
   void ProcessDefaultGraphics(fxcrt::ostringstream* buf);
   void ProcessText(fxcrt::ostringstream* buf, CPDF_TextObject* pTextObj);

--- a/core/fpdfapi/edit/cpdf_text_redactor.cpp
+++ b/core/fpdfapi/edit/cpdf_text_redactor.cpp
@@ -21,6 +21,7 @@
 #include "core/fpdfapi/page/cpdf_pageobjectholder.h"
 #include "core/fpdfapi/page/cpdf_textobject.h"
 #include "core/fpdfapi/page/cpdf_pathobject.h"
+#include "core/fpdfapi/page/cpdf_shadingobject.h"
 #include "core/fpdfapi/page/cpdf_colorspace.h"
 #include "core/fpdfapi/page/cpdf_dib.h"
 #include "core/fpdfapi/page/cpdf_image.h"
@@ -845,6 +846,28 @@ bool RedactHolder(CPDF_Page* page_for_cache,
           path->SetDirty(true);
         }
         changed = true;
+      }
+      continue;
+    }
+
+    if (CPDF_ShadingObject* shading = po->AsShading()) {
+      // Shading objects have a bounding box - check if it's fully inside any redaction rect
+      CFX_FloatRect shading_bbox = shading->GetRect();
+      
+      // Transform to page space
+      CFX_FloatRect bbox_page = to_page.TransformRect(shading_bbox);
+      bbox_page.Normalize();
+      
+      // Check if the shading bbox is fully inside any redaction rect
+      for (const auto& redact_rect : page_rects) {
+        if (bbox_page.left >= redact_rect.left &&
+            bbox_page.right <= redact_rect.right &&
+            bbox_page.bottom >= redact_rect.bottom &&
+            bbox_page.top <= redact_rect.top) {
+          to_remove.push_back(shading);
+          changed = true;
+          break;
+        }
       }
       continue;
     }


### PR DESCRIPTION
Introduces handling for CPDF_ShadingObject in CPDF_PageContentGenerator, including resource realization and graphics state emission. Updates the redactor to allow removal of shading objects fully covered by redaction rectangles. Also adds necessary includes and resource key for 'Shading'.