### PR TITLE
Add experimental AES-256 encryption API (EPDF_SetEncryption)

### DIFF
--- a/core/fpdfapi/edit/cpdf_creator.cpp
+++ b/core/fpdfapi/edit/cpdf_creator.cpp
@@ -696,6 +696,15 @@ void CPDF_Creator::RemoveSecurity() {
   new_encrypt_dict_.Reset();
 }
 
+void CPDF_Creator::SetEncryption(
+    RetainPtr<CPDF_Dictionary> encrypt_dict,
+    RetainPtr<CPDF_SecurityHandler> security_handler) {
+  new_encrypt_dict_ = std::move(encrypt_dict);
+  encrypt_dict_ = new_encrypt_dict_;
+  security_handler_ = std::move(security_handler);
+  security_changed_ = true;
+}
+
 CPDF_CryptoHandler* CPDF_Creator::GetCryptoHandler() {
   return security_handler_ ? security_handler_->GetCryptoHandler() : nullptr;
 }

--- a/core/fpdfapi/edit/cpdf_creator.h
+++ b/core/fpdfapi/edit/cpdf_creator.h
@@ -36,6 +36,12 @@ class CPDF_Creator {
   bool Create(uint32_t flags);
   bool SetFileVersion(int32_t fileVersion);
 
+  // Experimental EmbedPDF Extension: Set encryption for documents that weren't
+  // originally encrypted. This sets both encrypt_dict_ (for trailer writing)
+  // and security_handler_ (for GetCryptoHandler() used in stream/string encryption).
+  void SetEncryption(RetainPtr<CPDF_Dictionary> encrypt_dict,
+                     RetainPtr<CPDF_SecurityHandler> security_handler);
+
  private:
   enum class Stage {
     kInvalid = -1,

--- a/core/fpdfapi/parser/cpdf_security_handler.cpp
+++ b/core/fpdfapi/parser/cpdf_security_handler.cpp
@@ -231,6 +231,22 @@ uint32_t CPDF_SecurityHandler::GetPermissions(bool get_owner_perms) const {
   return dwPermission;
 }
 
+bool CPDF_SecurityHandler::UnlockOwner(const ByteString& password) {
+  if (owner_unlocked_) {
+    return true;  // Already unlocked
+  }
+  if (password.IsEmpty()) {
+    return false;  // Owner password cannot be empty
+  }
+  // CheckPassword handles encoding internally (Latin1/UTF8 conversions)
+  // and calls AES256_CheckPassword for R>=5
+  if (CheckPassword(password, /*bOwner=*/true)) {
+    owner_unlocked_ = true;
+    return true;
+  }
+  return false;
+}
+
 static bool LoadCryptInfo(const CPDF_Dictionary* pEncryptDict,
                           const ByteString& name,
                           CPDF_CryptoHandler::Cipher* cipher,

--- a/core/fpdfapi/parser/cpdf_security_handler.cpp
+++ b/core/fpdfapi/parser/cpdf_security_handler.cpp
@@ -641,6 +641,43 @@ void CPDF_SecurityHandler::OnCreate(CPDF_Dictionary* pEncryptDict,
   InitCryptoHandler();
 }
 
+bool CPDF_SecurityHandler::OnCreateWithPasswords(
+    CPDF_Dictionary* pEncryptDict,
+    const ByteString& user_password,
+    const ByteString& owner_password) {
+  DCHECK(pEncryptDict);
+
+  CPDF_CryptoHandler::Cipher cipher = CPDF_CryptoHandler::Cipher::kNone;
+  size_t key_len = 0;
+  if (!LoadDict(pEncryptDict, &cipher, &key_len)) {
+    return false;
+  }
+
+  // Only support R=6 (AES-256) for dual-password creation
+  if (revision_ != 6) {
+    return false;
+  }
+
+  // Generate random file encryption key (32 bytes) directly
+  // Using 8 x uint32_t = 32 bytes from MT RNG, then copy to avoid alignment
+  // issues
+  static_assert(sizeof(encrypt_key_) == 32);
+  uint32_t random_key[8];
+  FX_Random_GenerateMT(random_key);
+  memcpy(encrypt_key_.data(), random_key, 32);
+
+  // Set all password entries (U, UE, O, OE)
+  AES256_SetPasswords(pEncryptDict, user_password, owner_password);
+
+  // Set Perms entry
+  AES256_SetPerms(pEncryptDict);
+
+  // Initialize crypto handler for encryption
+  InitCryptoHandler();
+
+  return true;
+}
+
 void CPDF_SecurityHandler::AES256_SetPassword(CPDF_Dictionary* pEncryptDict,
                                               const ByteString& password) {
   CRYPT_sha1_context sha;
@@ -716,6 +753,66 @@ void CPDF_SecurityHandler::AES256_SetPerms(CPDF_Dictionary* pEncryptDict) {
   CRYPT_AESEncrypt(&aes, dest, buf);
   pEncryptDict->SetNewFor<CPDF_String>(
       "Perms", ByteString(ByteStringView(pdfium::span(dest))));
+}
+
+void CPDF_SecurityHandler::AES256_SetPasswords(
+    CPDF_Dictionary* pEncryptDict,
+    const ByteString& user_password,
+    const ByteString& owner_password) {
+  // Generate 4 separate random salts (8 bytes each = 32 bytes total)
+  // Use uint8_t array so we can pass to Revision6_Hash directly
+  uint8_t salt_buffer[32];
+  uint32_t random_salt[8];
+  FX_Random_GenerateMT(random_salt);
+  memcpy(salt_buffer, random_salt, 32);
+
+  // Create salt spans matching Revision6_Hash signature (span<const uint8_t,8>)
+  auto u_val_salt = pdfium::span(salt_buffer).subspan<0, 8>();
+  auto u_key_salt = pdfium::span(salt_buffer).subspan<8, 8>();
+  auto o_val_salt = pdfium::span(salt_buffer).subspan<16, 8>();
+  auto o_key_salt = pdfium::span(salt_buffer).subspan<24, 8>();
+
+  uint8_t hash[32];
+  uint8_t U[48], UE[32], O[48], OE[32];
+
+  // --- Compute U (user validation - NO U dependency) ---
+  Revision6_Hash(user_password, u_val_salt, std::nullopt,
+                 pdfium::span(hash).first<32u>());
+  fxcrt::Copy(pdfium::span(hash), pdfium::span(U).first<32u>());
+  fxcrt::Copy(u_val_salt, pdfium::span(U).subspan<32, 8>());
+  fxcrt::Copy(u_key_salt, pdfium::span(U).subspan<40, 8>());
+  pEncryptDict->SetNewFor<CPDF_String>(
+      "U", ByteString(ByteStringView(pdfium::span(U))));
+
+  // --- Compute UE (user encrypted key) ---
+  Revision6_Hash(user_password, u_key_salt, std::nullopt,
+                 pdfium::span(hash).first<32u>());
+  CRYPT_aes_context aes = {};
+  uint8_t iv[16] = {};
+  CRYPT_AESSetKey(&aes, hash);
+  CRYPT_AESSetIV(&aes, iv);
+  CRYPT_AESEncrypt(&aes, UE, encrypt_key_);
+  pEncryptDict->SetNewFor<CPDF_String>(
+      "UE", ByteString(ByteStringView(pdfium::span(UE))));
+
+  // --- Compute O (owner validation - INCLUDES U) ---
+  auto U_span = pdfium::span(U).first<48>();
+  Revision6_Hash(owner_password, o_val_salt, U_span,
+                 pdfium::span(hash).first<32u>());
+  fxcrt::Copy(pdfium::span(hash), pdfium::span(O).first<32u>());
+  fxcrt::Copy(o_val_salt, pdfium::span(O).subspan<32, 8>());
+  fxcrt::Copy(o_key_salt, pdfium::span(O).subspan<40, 8>());
+  pEncryptDict->SetNewFor<CPDF_String>(
+      "O", ByteString(ByteStringView(pdfium::span(O))));
+
+  // --- Compute OE (owner encrypted key - INCLUDES U) ---
+  Revision6_Hash(owner_password, o_key_salt, U_span,
+                 pdfium::span(hash).first<32u>());
+  CRYPT_AESSetKey(&aes, hash);
+  CRYPT_AESSetIV(&aes, iv);
+  CRYPT_AESEncrypt(&aes, OE, encrypt_key_);
+  pEncryptDict->SetNewFor<CPDF_String>(
+      "OE", ByteString(ByteStringView(pdfium::span(OE))));
 }
 
 void CPDF_SecurityHandler::InitCryptoHandler() {

--- a/core/fpdfapi/parser/cpdf_security_handler.h
+++ b/core/fpdfapi/parser/cpdf_security_handler.h
@@ -54,6 +54,9 @@ class CPDF_SecurityHandler final : public Retainable {
   // Returns false if password is invalid, empty, or document isn't encrypted.
   bool UnlockOwner(const ByteString& password);
 
+  // Returns true if owner permissions are currently unlocked.
+  bool IsOwnerUnlocked() const { return owner_unlocked_; }
+
  private:
   enum PasswordEncodingConversion {
     kUnknown,

--- a/core/fpdfapi/parser/cpdf_security_handler.h
+++ b/core/fpdfapi/parser/cpdf_security_handler.h
@@ -31,6 +31,12 @@ class CPDF_SecurityHandler final : public Retainable {
                 const CPDF_Array* pIdArray,
                 const ByteString& password);
 
+  // New method for AES-256 R=6 with both passwords.
+  // Returns true on success, false if LoadDict fails or revision is not 6.
+  bool OnCreateWithPasswords(CPDF_Dictionary* pEncryptDict,
+                             const ByteString& user_password,
+                             const ByteString& owner_password);
+
   // When `get_owner_perms` is true, returns full permissions if unlocked by
   // owner.
   uint32_t GetPermissions(bool get_owner_perms) const;
@@ -67,6 +73,10 @@ class CPDF_SecurityHandler final : public Retainable {
   void AES256_SetPassword(CPDF_Dictionary* pEncryptDict,
                           const ByteString& password);
   void AES256_SetPerms(CPDF_Dictionary* pEncryptDict);
+  // Helper that sets U, UE, O, OE for R=6 with both user and owner passwords
+  void AES256_SetPasswords(CPDF_Dictionary* pEncryptDict,
+                           const ByteString& user_password,
+                           const ByteString& owner_password);
   bool CheckSecurity(const ByteString& password);
 
   void InitCryptoHandler();

--- a/core/fpdfapi/parser/cpdf_security_handler.h
+++ b/core/fpdfapi/parser/cpdf_security_handler.h
@@ -48,6 +48,12 @@ class CPDF_SecurityHandler final : public Retainable {
   // conversion.
   ByteString GetEncodedPassword(ByteStringView password) const;
 
+  // Attempts to unlock owner permissions using the given password.
+  // Password encoding is handled internally (same as load-time path).
+  // Returns true if the password is valid and owner_unlocked_ is now true.
+  // Returns false if password is invalid, empty, or document isn't encrypted.
+  bool UnlockOwner(const ByteString& password);
+
  private:
   enum PasswordEncodingConversion {
     kUnknown,

--- a/fpdfsdk/fpdf_save.cpp
+++ b/fpdfsdk/fpdf_save.cpp
@@ -27,13 +27,15 @@
 #include "fpdfsdk/cpdfsdk_helpers.h"
 #include "public/fpdf_edit.h"
 
-// External pending encryption storage defined in fpdf_view.cpp
-struct PendingEncryption {
+// External pending security storage defined in fpdf_view.cpp
+enum class PendingSecurityMode { kNone, kEncrypt, kRemove };
+struct PendingSecurity {
+  PendingSecurityMode mode = PendingSecurityMode::kNone;
   RetainPtr<CPDF_Dictionary> encrypt_dict;
   RetainPtr<CPDF_SecurityHandler> security_handler;
 };
-extern std::mutex g_pending_encryption_mutex;
-extern std::unordered_map<FPDF_DOCUMENT, PendingEncryption> g_pending_encryptions;
+extern std::mutex g_pending_security_mutex;
+extern std::unordered_map<FPDF_DOCUMENT, PendingSecurity> g_pending_security;
 
 #ifdef PDF_ENABLE_XFA
 #include "core/fpdfapi/parser/cpdf_stream.h"
@@ -198,25 +200,29 @@ bool DoDocSave(FPDF_DOCUMENT document,
     fileMaker.SetFileVersion(version.value());
   }
 
-  // Apply pending encryption BEFORE Create() is called
-  // This ensures encrypt_dict_ and security_handler_ are set on the creator
-  {
-    std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
-    auto it = g_pending_encryptions.find(document);
-    if (it != g_pending_encryptions.end()) {
-      // SetEncryption sets both:
-      // 1. encrypt_dict_ - so /Encrypt reference is written to trailer
-      // 2. security_handler_ - so GetCryptoHandler() encrypts streams/strings
-      fileMaker.SetEncryption(it->second.encrypt_dict,
-                              it->second.security_handler);
+  // Security handling: explicit FPDF_REMOVE_SECURITY flag takes highest
+  // precedence, then pending security state
+  if (flags == FPDF_REMOVE_SECURITY) {
+    // Explicit flag wins - always remove security
+    flags = 0;
+    fileMaker.RemoveSecurity();
+  } else {
+    // Apply pending security state
+    std::lock_guard<std::mutex> lock(g_pending_security_mutex);
+    auto it = g_pending_security.find(document);
+    if (it != g_pending_security.end()) {
+      if (it->second.mode == PendingSecurityMode::kRemove) {
+        fileMaker.RemoveSecurity();
+      } else if (it->second.mode == PendingSecurityMode::kEncrypt) {
+        // SetEncryption sets both:
+        // 1. encrypt_dict_ - so /Encrypt reference is written to trailer
+        // 2. security_handler_ - so GetCryptoHandler() encrypts streams/strings
+        fileMaker.SetEncryption(it->second.encrypt_dict,
+                                it->second.security_handler);
+      }
       // Don't erase from map here - leave for cleanup on doc close
       // This allows multiple saves of the same encrypted doc
     }
-  }
-
-  if (flags == FPDF_REMOVE_SECURITY) {
-    flags = 0;
-    fileMaker.RemoveSecurity();
   }
 
   bool bRet = fileMaker.Create(static_cast<uint32_t>(flags));

--- a/fpdfsdk/fpdf_save.cpp
+++ b/fpdfsdk/fpdf_save.cpp
@@ -6,7 +6,9 @@
 
 #include "public/fpdf_save.h"
 
+#include <mutex>
 #include <optional>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -16,6 +18,7 @@
 #include "core/fpdfapi/parser/cpdf_dictionary.h"
 #include "core/fpdfapi/parser/cpdf_document.h"
 #include "core/fpdfapi/parser/cpdf_reference.h"
+#include "core/fpdfapi/parser/cpdf_security_handler.h"
 #include "core/fpdfapi/parser/cpdf_stream_acc.h"
 #include "core/fpdfapi/parser/cpdf_string.h"
 #include "core/fxcrt/fx_extension.h"
@@ -23,6 +26,14 @@
 #include "fpdfsdk/cpdfsdk_filewriteadapter.h"
 #include "fpdfsdk/cpdfsdk_helpers.h"
 #include "public/fpdf_edit.h"
+
+// External pending encryption storage defined in fpdf_view.cpp
+struct PendingEncryption {
+  RetainPtr<CPDF_Dictionary> encrypt_dict;
+  RetainPtr<CPDF_SecurityHandler> security_handler;
+};
+extern std::mutex g_pending_encryption_mutex;
+extern std::unordered_map<FPDF_DOCUMENT, PendingEncryption> g_pending_encryptions;
 
 #ifdef PDF_ENABLE_XFA
 #include "core/fpdfapi/parser/cpdf_stream.h"
@@ -186,6 +197,23 @@ bool DoDocSave(FPDF_DOCUMENT document,
   if (version.has_value()) {
     fileMaker.SetFileVersion(version.value());
   }
+
+  // Apply pending encryption BEFORE Create() is called
+  // This ensures encrypt_dict_ and security_handler_ are set on the creator
+  {
+    std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
+    auto it = g_pending_encryptions.find(document);
+    if (it != g_pending_encryptions.end()) {
+      // SetEncryption sets both:
+      // 1. encrypt_dict_ - so /Encrypt reference is written to trailer
+      // 2. security_handler_ - so GetCryptoHandler() encrypts streams/strings
+      fileMaker.SetEncryption(it->second.encrypt_dict,
+                              it->second.security_handler);
+      // Don't erase from map here - leave for cleanup on doc close
+      // This allows multiple saves of the same encrypted doc
+    }
+  }
+
   if (flags == FPDF_REMOVE_SECURITY) {
     flags = 0;
     fileMaker.RemoveSecurity();

--- a/fpdfsdk/fpdf_view.cpp
+++ b/fpdfsdk/fpdf_view.cpp
@@ -621,6 +621,41 @@ EPDF_UnlockOwnerPermissions(FPDF_DOCUMENT document,
   return security_handler->UnlockOwner(password);
 }
 
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_IsEncrypted(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc) {
+    return false;
+  }
+
+  CPDF_Parser* pParser = pDoc->GetParser();
+  if (!pParser) {
+    return false;
+  }
+
+  return pParser->GetSecurityHandler() != nullptr;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_IsOwnerUnlocked(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc) {
+    return false;
+  }
+
+  CPDF_Parser* pParser = pDoc->GetParser();
+  if (!pParser) {
+    return false;
+  }
+
+  const auto& security_handler = pParser->GetSecurityHandler();
+  if (!security_handler) {
+    return false;  // Not encrypted
+  }
+
+  return security_handler->IsOwnerUnlocked();
+}
+
 FPDF_EXPORT int FPDF_CALLCONV FPDF_GetPageCount(FPDF_DOCUMENT document) {
   auto* pDoc = CPDFDocumentFromFPDFDocument(document);
   if (!pDoc) {

--- a/fpdfsdk/fpdf_view.cpp
+++ b/fpdfsdk/fpdf_view.cpp
@@ -597,6 +597,30 @@ EPDF_RemoveEncryption(FPDF_DOCUMENT document) {
   return true;
 }
 
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_UnlockOwnerPermissions(FPDF_DOCUMENT document,
+                            FPDF_BYTESTRING owner_password) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc) {
+    return false;
+  }
+
+  CPDF_Parser* pParser = pDoc->GetParser();
+  if (!pParser) {
+    return false;  // Document wasn't loaded from file
+  }
+
+  const auto& security_handler = pParser->GetSecurityHandler();
+  if (!security_handler) {
+    return false;  // Document isn't encrypted
+  }
+
+  // Pass raw password - encoding is handled inside UnlockOwner/CheckPassword
+  // DO NOT call GetEncodedPassword here - that would double-encode
+  ByteString password(owner_password ? owner_password : "");
+  return security_handler->UnlockOwner(password);
+}
+
 FPDF_EXPORT int FPDF_CALLCONV FPDF_GetPageCount(FPDF_DOCUMENT document) {
   auto* pDoc = CPDFDocumentFromFPDFDocument(document);
   if (!pDoc) {

--- a/fpdfsdk/fpdf_view.cpp
+++ b/fpdfsdk/fpdf_view.cpp
@@ -8,6 +8,8 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -20,10 +22,13 @@
 #include "core/fpdfdoc/cpdf_annot.h"
 #include "core/fpdfapi/page/cpdf_annotcontext.h"
 #include "core/fpdfapi/parser/cpdf_array.h"
+#include "core/fpdfapi/parser/cpdf_boolean.h"
 #include "core/fpdfapi/parser/cpdf_dictionary.h"
+#include "core/fpdfapi/parser/cpdf_number.h"
 #include "core/fpdfapi/parser/cpdf_document.h"
 #include "core/fpdfapi/parser/cpdf_name.h"
 #include "core/fpdfapi/parser/cpdf_parser.h"
+#include "core/fpdfapi/parser/cpdf_security_handler.h"
 #include "core/fpdfapi/parser/cpdf_stream.h"
 #include "core/fpdfapi/parser/cpdf_string.h"
 #include "core/fpdfapi/parser/fpdf_parser_decode.h"
@@ -118,6 +123,24 @@ static_assert(static_cast<int>(CFX_DefaultRenderDevice::RendererType::kSkia) ==
                   FPDF_RENDERERTYPE_SKIA,
               "CFX_DefaultRenderDevice::RendererType::kSkia value mismatch");
 #endif  // defined(PDF_USE_SKIA)
+
+// Experimental EmbedPDF Extension: Pending encryption storage
+// Stores encryption settings to apply during save
+struct PendingEncryption {
+  RetainPtr<CPDF_Dictionary> encrypt_dict;
+  RetainPtr<CPDF_SecurityHandler> security_handler;
+};
+
+// Thread-safe storage - keyed by FPDF_DOCUMENT handle
+// Note: NOT static - needs external linkage for fpdf_save.cpp
+std::mutex g_pending_encryption_mutex;
+std::unordered_map<FPDF_DOCUMENT, PendingEncryption> g_pending_encryptions;
+
+// Helper to cleanup pending encryption on document close
+void EPDF_CleanupPendingEncryption(FPDF_DOCUMENT doc) {
+  std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
+  g_pending_encryptions.erase(doc);
+}
 
 namespace {
 
@@ -457,6 +480,136 @@ FPDF_GetSecurityHandlerRevision(FPDF_DOCUMENT document) {
 
   RetainPtr<const CPDF_Dictionary> dict = pDoc->GetParser()->GetEncryptDict();
   return dict ? dict->GetIntegerFor("R") : -1;
+}
+
+namespace {
+
+// Build P value with correct reserved bits for R>=3 (including R=4 and R=6)
+// Input: allowed_flags - OR'd combination of permission bits user wants to ALLOW
+// Output: proper P value with reserved bits set correctly
+uint32_t BuildPermissionsForRevision(uint32_t allowed_flags) {
+  // Enforce: PrintHighQuality implies Print (bit 12 requires bit 3)
+  // Some readers interpret oddly if PRINT_HIGH is set without PRINT
+  if (allowed_flags & EPDF_PERM_PRINT_HIGH) {
+    allowed_flags |= EPDF_PERM_PRINT;
+  }
+
+  // Start with allowed flags
+  uint32_t p = allowed_flags;
+
+  // Apply reserved bit requirements (PDF Reference 1.7, Table 3.20)
+  // Bits 1-2 must be 0
+  p &= 0xFFFFFFFC;
+  // Bits 7-8 must be 1 (for R>=3)
+  // Bits 13-32 must be 1
+  p |= 0xFFFFF0C0;
+
+  return p;
+}
+
+}  // namespace
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_SetEncryption(FPDF_DOCUMENT document,
+                   FPDF_BYTESTRING user_password,
+                   FPDF_BYTESTRING owner_password,
+                   unsigned long allowed_flags) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc) {
+    return false;
+  }
+
+  // Require owner password
+  if (!owner_password || strlen(owner_password) == 0) {
+    return false;
+  }
+
+  // Check if already encrypted - check parser for loaded documents
+  if (pDoc->GetParser() && pDoc->GetParser()->GetEncryptDict()) {
+    // Already encrypted from file - cannot re-key with this API.
+    // To change password on encrypted doc:
+    //   1. Save decrypted copy using FPDF_REMOVE_SECURITY flag
+    //   2. Reload that output
+    //   3. Call EPDF_SetEncryption on the reloaded doc
+    //   4. Save again
+    return false;
+  }
+
+  // Check if pending encryption already set
+  {
+    std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
+    if (g_pending_encryptions.find(document) != g_pending_encryptions.end()) {
+      return false;  // Already has pending encryption set
+    }
+  }
+
+  // Validation passed - create encrypt dict AFTER validation to avoid leaking
+  // objects on error
+
+  // Create as INDIRECT object owned by document
+  auto pEncryptDict = pDoc->NewIndirect<CPDF_Dictionary>();
+
+  // Set encryption parameters for AES-256 (V=5, R=6)
+  pEncryptDict->SetNewFor<CPDF_Name>("Filter", "Standard");
+  pEncryptDict->SetNewFor<CPDF_Number>("V", 5);
+  pEncryptDict->SetNewFor<CPDF_Number>("R", 6);
+  pEncryptDict->SetNewFor<CPDF_Number>("Length", 256);
+
+  // IMPORTANT: P value must be written as SIGNED int32 (negative when bits
+  // 13-32 are set)
+  int32_t p_signed =
+      static_cast<int32_t>(BuildPermissionsForRevision(allowed_flags));
+  pEncryptDict->SetNewFor<CPDF_Number>("P", p_signed);
+  pEncryptDict->SetNewFor<CPDF_Boolean>("EncryptMetadata", true);
+
+  // Crypt filter for AES-256 - CFM must be "AESV3"
+  auto pCF = pEncryptDict->SetNewFor<CPDF_Dictionary>("CF");
+  auto pStdCF = pCF->SetNewFor<CPDF_Dictionary>("StdCF");
+  pStdCF->SetNewFor<CPDF_Name>("Type", "CryptFilter");
+  pStdCF->SetNewFor<CPDF_Name>("CFM", "AESV3");
+  pStdCF->SetNewFor<CPDF_Name>("AuthEvent", "DocOpen");
+  pStdCF->SetNewFor<CPDF_Number>("Length", 32);
+
+  pEncryptDict->SetNewFor<CPDF_Name>("StmF", "StdCF");
+  pEncryptDict->SetNewFor<CPDF_Name>("StrF", "StdCF");
+
+  // Create security handler and call OnCreate to generate U, UE, O, OE, Perms
+  auto pSecurityHandler = pdfium::MakeRetain<CPDF_SecurityHandler>();
+
+  // Set permissions on the handler before calling OnCreate
+  // The handler uses these internally
+  ByteString owner_pwd(owner_password);
+  ByteString user_pwd(user_password ? user_password : "");
+
+  // OnCreate generates U, UE, O, OE, Perms entries in the encrypt dict
+  // For AES-256 (R>=5), it uses random key derivation (doesn't need ID array)
+  pSecurityHandler->OnCreate(pEncryptDict.Get(), nullptr, owner_pwd);
+
+  // Store pending encryption
+  {
+    std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
+    PendingEncryption pending;
+    pending.encrypt_dict = std::move(pEncryptDict);
+    pending.security_handler = std::move(pSecurityHandler);
+    g_pending_encryptions[document] = std::move(pending);
+  }
+
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveEncryption(FPDF_DOCUMENT document) {
+  if (!document) {
+    return false;
+  }
+
+  // Clear any pending encryption using FPDF_DOCUMENT handle as key
+  std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
+  g_pending_encryptions.erase(document);
+
+  // Note: For already-encrypted docs, user should use FPDF_REMOVE_SECURITY flag
+  // on save
+  return true;
 }
 
 FPDF_EXPORT int FPDF_CALLCONV FPDF_GetPageCount(FPDF_DOCUMENT document) {
@@ -938,6 +1091,9 @@ FPDF_EXPORT void FPDF_CALLCONV FPDF_ClosePage(FPDF_PAGE page) {
 }
 
 FPDF_EXPORT void FPDF_CALLCONV FPDF_CloseDocument(FPDF_DOCUMENT document) {
+  // Cleanup pending encryption BEFORE deletion
+  EPDF_CleanupPendingEncryption(document);
+
   // Take it back across the API and throw it away,
   std::unique_ptr<CPDF_Document>(CPDFDocumentFromFPDFDocument(document));
 }

--- a/fpdfsdk/fpdf_view.cpp
+++ b/fpdfsdk/fpdf_view.cpp
@@ -124,22 +124,25 @@ static_assert(static_cast<int>(CFX_DefaultRenderDevice::RendererType::kSkia) ==
               "CFX_DefaultRenderDevice::RendererType::kSkia value mismatch");
 #endif  // defined(PDF_USE_SKIA)
 
-// Experimental EmbedPDF Extension: Pending encryption storage
-// Stores encryption settings to apply during save
-struct PendingEncryption {
-  RetainPtr<CPDF_Dictionary> encrypt_dict;
-  RetainPtr<CPDF_SecurityHandler> security_handler;
+// Experimental EmbedPDF Extension: Pending security storage
+// Unified structure for pending encryption or removal
+enum class PendingSecurityMode { kNone, kEncrypt, kRemove };
+
+struct PendingSecurity {
+  PendingSecurityMode mode = PendingSecurityMode::kNone;
+  RetainPtr<CPDF_Dictionary> encrypt_dict;      // Only for kEncrypt
+  RetainPtr<CPDF_SecurityHandler> security_handler;  // Only for kEncrypt
 };
 
 // Thread-safe storage - keyed by FPDF_DOCUMENT handle
 // Note: NOT static - needs external linkage for fpdf_save.cpp
-std::mutex g_pending_encryption_mutex;
-std::unordered_map<FPDF_DOCUMENT, PendingEncryption> g_pending_encryptions;
+std::mutex g_pending_security_mutex;
+std::unordered_map<FPDF_DOCUMENT, PendingSecurity> g_pending_security;
 
-// Helper to cleanup pending encryption on document close
-void EPDF_CleanupPendingEncryption(FPDF_DOCUMENT doc) {
-  std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
-  g_pending_encryptions.erase(doc);
+// Helper to cleanup pending security on document close
+void EPDF_CleanupPendingSecurity(FPDF_DOCUMENT doc) {
+  std::lock_guard<std::mutex> lock(g_pending_security_mutex);
+  g_pending_security.erase(doc);
 }
 
 namespace {
@@ -514,84 +517,64 @@ EPDF_SetEncryption(FPDF_DOCUMENT document,
                    FPDF_BYTESTRING user_password,
                    FPDF_BYTESTRING owner_password,
                    unsigned long allowed_flags) {
+  // Validation
+  if (!document || !owner_password || !*owner_password) {
+    return false;
+  }
+
   CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
   if (!pDoc) {
     return false;
   }
 
-  // Require owner password
-  if (!owner_password || strlen(owner_password) == 0) {
-    return false;
-  }
+  // NOTE: We allow re-keying already encrypted documents.
+  // User opens with old password, calls setEncryption with new, saves.
 
-  // Check if already encrypted - check parser for loaded documents
-  if (pDoc->GetParser() && pDoc->GetParser()->GetEncryptDict()) {
-    // Already encrypted from file - cannot re-key with this API.
-    // To change password on encrypted doc:
-    //   1. Save decrypted copy using FPDF_REMOVE_SECURITY flag
-    //   2. Reload that output
-    //   3. Call EPDF_SetEncryption on the reloaded doc
-    //   4. Save again
-    return false;
-  }
+  // Build permissions P value (negative, with reserved bits set)
+  int32_t permissions =
+      static_cast<int32_t>(BuildPermissionsForRevision(allowed_flags));
 
-  // Check if pending encryption already set
-  {
-    std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
-    if (g_pending_encryptions.find(document) != g_pending_encryptions.end()) {
-      return false;  // Already has pending encryption set
-    }
-  }
-
-  // Validation passed - create encrypt dict AFTER validation to avoid leaking
-  // objects on error
-
-  // Create as INDIRECT object owned by document
+  // Create encrypt dictionary as indirect object
   auto pEncryptDict = pDoc->NewIndirect<CPDF_Dictionary>();
-
-  // Set encryption parameters for AES-256 (V=5, R=6)
   pEncryptDict->SetNewFor<CPDF_Name>("Filter", "Standard");
   pEncryptDict->SetNewFor<CPDF_Number>("V", 5);
   pEncryptDict->SetNewFor<CPDF_Number>("R", 6);
   pEncryptDict->SetNewFor<CPDF_Number>("Length", 256);
-
-  // IMPORTANT: P value must be written as SIGNED int32 (negative when bits
-  // 13-32 are set)
-  int32_t p_signed =
-      static_cast<int32_t>(BuildPermissionsForRevision(allowed_flags));
-  pEncryptDict->SetNewFor<CPDF_Number>("P", p_signed);
+  pEncryptDict->SetNewFor<CPDF_Number>("P", permissions);
   pEncryptDict->SetNewFor<CPDF_Boolean>("EncryptMetadata", true);
 
-  // Crypt filter for AES-256 - CFM must be "AESV3"
+  // Crypt filters for AES-256
   auto pCF = pEncryptDict->SetNewFor<CPDF_Dictionary>("CF");
   auto pStdCF = pCF->SetNewFor<CPDF_Dictionary>("StdCF");
   pStdCF->SetNewFor<CPDF_Name>("Type", "CryptFilter");
   pStdCF->SetNewFor<CPDF_Name>("CFM", "AESV3");
   pStdCF->SetNewFor<CPDF_Name>("AuthEvent", "DocOpen");
   pStdCF->SetNewFor<CPDF_Number>("Length", 32);
-
   pEncryptDict->SetNewFor<CPDF_Name>("StmF", "StdCF");
   pEncryptDict->SetNewFor<CPDF_Name>("StrF", "StdCF");
 
-  // Create security handler and call OnCreate to generate U, UE, O, OE, Perms
+  // Create security handler and initialize with BOTH passwords
   auto pSecurityHandler = pdfium::MakeRetain<CPDF_SecurityHandler>();
-
-  // Set permissions on the handler before calling OnCreate
-  // The handler uses these internally
   ByteString owner_pwd(owner_password);
   ByteString user_pwd(user_password ? user_password : "");
 
-  // OnCreate generates U, UE, O, OE, Perms entries in the encrypt dict
-  // For AES-256 (R>=5), it uses random key derivation (doesn't need ID array)
-  pSecurityHandler->OnCreate(pEncryptDict.Get(), nullptr, owner_pwd);
+  // OnCreateWithPasswords properly sets U, UE, O, OE, Perms for R=6
+  // Returns false if LoadDict fails or R != 6
+  if (!pSecurityHandler->OnCreateWithPasswords(pEncryptDict.Get(), user_pwd,
+                                               owner_pwd)) {
+    // Cleanup the indirect object we created
+    pDoc->DeleteIndirectObject(pEncryptDict->GetObjNum());
+    return false;
+  }
 
-  // Store pending encryption
+  // Store (OVERWRITE if exists - allows changing password multiple times)
   {
-    std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
-    PendingEncryption pending;
+    std::lock_guard<std::mutex> lock(g_pending_security_mutex);
+    PendingSecurity pending;
+    pending.mode = PendingSecurityMode::kEncrypt;
     pending.encrypt_dict = std::move(pEncryptDict);
     pending.security_handler = std::move(pSecurityHandler);
-    g_pending_encryptions[document] = std::move(pending);
+    g_pending_security[document] = std::move(pending);
   }
 
   return true;
@@ -603,12 +586,14 @@ EPDF_RemoveEncryption(FPDF_DOCUMENT document) {
     return false;
   }
 
-  // Clear any pending encryption using FPDF_DOCUMENT handle as key
-  std::lock_guard<std::mutex> lock(g_pending_encryption_mutex);
-  g_pending_encryptions.erase(document);
+  // Set pending security to removal mode
+  // This will cause RemoveSecurity() to be called during save
+  std::lock_guard<std::mutex> lock(g_pending_security_mutex);
+  PendingSecurity pending;
+  pending.mode = PendingSecurityMode::kRemove;
+  // encrypt_dict and security_handler remain null for removal
+  g_pending_security[document] = std::move(pending);
 
-  // Note: For already-encrypted docs, user should use FPDF_REMOVE_SECURITY flag
-  // on save
   return true;
 }
 
@@ -1091,8 +1076,8 @@ FPDF_EXPORT void FPDF_CALLCONV FPDF_ClosePage(FPDF_PAGE page) {
 }
 
 FPDF_EXPORT void FPDF_CALLCONV FPDF_CloseDocument(FPDF_DOCUMENT document) {
-  // Cleanup pending encryption BEFORE deletion
-  EPDF_CleanupPendingEncryption(document);
+  // Cleanup pending security BEFORE deletion
+  EPDF_CleanupPendingSecurity(document);
 
   // Take it back across the API and throw it away,
   std::unique_ptr<CPDF_Document>(CPDFDocumentFromFPDFDocument(document));

--- a/public/fpdfview.h
+++ b/public/fpdfview.h
@@ -734,6 +734,34 @@ FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
 EPDF_UnlockOwnerPermissions(FPDF_DOCUMENT document,
                             FPDF_BYTESTRING owner_password);
 
+// Experimental EmbedPDF Extension API.
+// Checks if a document is encrypted.
+//
+//   document - handle to a document
+//
+// Returns TRUE if the document has encryption (Standard security handler).
+// Returns FALSE if:
+//   - document is NULL
+//   - document has no parser
+//   - document is not encrypted
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_IsEncrypted(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
+// Checks if owner permissions are currently unlocked on an encrypted document.
+//
+//   document - handle to a document
+//
+// Returns TRUE if:
+//   - Document is encrypted AND owner password was verified (at load or via UnlockOwner)
+// Returns FALSE if:
+//   - document is NULL
+//   - document has no parser
+//   - document is not encrypted
+//   - owner permissions are not unlocked
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_IsOwnerUnlocked(FPDF_DOCUMENT document);
+
 // Function: FPDF_GetPageCount
 //          Get total number of pages in the document.
 // Parameters:

--- a/public/fpdfview.h
+++ b/public/fpdfview.h
@@ -672,6 +672,50 @@ FPDF_GetDocUserPermissions(FPDF_DOCUMENT document);
 FPDF_EXPORT int FPDF_CALLCONV
 FPDF_GetSecurityHandlerRevision(FPDF_DOCUMENT document);
 
+// Permission flags for EPDF_SetEncryption allowed_flags parameter
+#define EPDF_PERM_PRINT              (1 << 2)   // Bit 3: Print document
+#define EPDF_PERM_MODIFY             (1 << 3)   // Bit 4: Modify contents
+#define EPDF_PERM_COPY               (1 << 4)   // Bit 5: Copy/extract text
+#define EPDF_PERM_ANNOT              (1 << 5)   // Bit 6: Add/modify annotations
+#define EPDF_PERM_FILL_FORMS         (1 << 8)   // Bit 9: Fill form fields
+#define EPDF_PERM_ACCESSIBILITY      (1 << 9)   // Bit 10: Extract for accessibility
+#define EPDF_PERM_ASSEMBLE           (1 << 10)  // Bit 11: Assemble document
+#define EPDF_PERM_PRINT_HIGH         (1 << 11)  // Bit 12: High quality print
+
+// Experimental EmbedPDF Extension API.
+// Sets AES-256 encryption on a document with user/owner passwords and permissions.
+//
+//   document        - handle to a document. Must not already be encrypted.
+//   user_password   - password required to open the document.
+//                     NULL or empty = no open password (document opens freely
+//                     but has owner restrictions enforced by compliant readers).
+//   owner_password  - password required to change permissions. Required, cannot
+//                     be NULL or empty.
+//   allowed_flags   - OR'd combination of EPDF_PERM_* flags indicating which
+//                     actions ARE ALLOWED. Internally converted to proper P value.
+//
+// Returns TRUE on success, FALSE on failure (e.g., already encrypted, NULL
+// owner password).
+// Note: Must be called before FPDF_SaveAsCopy for encryption to take effect.
+//
+// Example allowed_flags: EPDF_PERM_PRINT | EPDF_PERM_COPY
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_SetEncryption(FPDF_DOCUMENT document,
+                   FPDF_BYTESTRING user_password,
+                   FPDF_BYTESTRING owner_password,
+                   unsigned long allowed_flags);
+
+// Experimental EmbedPDF Extension API.
+// Clears any pending encryption set by EPDF_SetEncryption.
+// To remove encryption from an already-encrypted document, use
+// FPDF_REMOVE_SECURITY flag with FPDF_SaveAsCopy instead.
+//
+//   document - handle to a document.
+//
+// Returns TRUE on success.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveEncryption(FPDF_DOCUMENT document);
+
 // Function: FPDF_GetPageCount
 //          Get total number of pages in the document.
 // Parameters:

--- a/public/fpdfview.h
+++ b/public/fpdfview.h
@@ -716,6 +716,24 @@ EPDF_SetEncryption(FPDF_DOCUMENT document,
 FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
 EPDF_RemoveEncryption(FPDF_DOCUMENT document);
 
+// Experimental EmbedPDF Extension API.
+// Attempts to unlock owner permissions on an already-opened encrypted document.
+//
+//   document        - handle to a document
+//   owner_password  - the owner password to verify (raw, encoding handled internally)
+//
+// Returns TRUE if the password is valid and owner permissions are now unlocked.
+// Returns FALSE if:
+//   - document is NULL
+//   - document has no parser (not loaded from file)
+//   - document is not encrypted
+//   - password is empty or invalid
+//
+// After successful unlock, FPDF_GetDocPermissions() will return full permissions.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_UnlockOwnerPermissions(FPDF_DOCUMENT document,
+                            FPDF_BYTESTRING owner_password);
+
 // Function: FPDF_GetPageCount
 //          Get total number of pages in the document.
 // Parameters:


### PR DESCRIPTION
Introduces an experimental EmbedPDF extension API for setting AES-256 encryption on unencrypted documents, allowing user/owner passwords and configurable permissions. Implements thread-safe pending encryption storage, applies encryption during save, and provides EPDF_RemoveEncryption to clear pending settings. Updates public headers with new permission flags and API documentation.