### PR TITLE
Add page rotation normalization APIs

### DIFF
--- a/core/fpdfapi/page/cpdf_page.cpp
+++ b/core/fpdfapi/page/cpdf_page.cpp
@@ -195,10 +195,30 @@ CFX_Matrix CPDF_Page::GetDisplayMatrix() const {
 }
 
 int CPDF_Page::GetPageRotation() const {
+  // EmbedPDF: If rotation override is set, use it instead of dictionary value
+  if (rotation_override_.has_value()) {
+    return rotation_override_.value();
+  }
+  return GetOriginalRotation();
+}
+
+int CPDF_Page::GetOriginalRotation() const {
+  // Always read from dictionary, ignoring any override
   RetainPtr<const CPDF_Object> pRotate =
       GetPageAttr(pdfium::page_object::kRotate);
   int rotation = pRotate ? (pRotate->GetInteger() / 90) % 4 : 0;
   return (rotation < 0) ? (rotation + 4) : rotation;
+}
+
+void CPDF_Page::SetRotationOverride(int rotation) {
+  // Set override (-1 clears it)
+  if (rotation < 0) {
+    rotation_override_.reset();
+  } else {
+    rotation_override_ = rotation % 4;
+  }
+  // Recalculate dimensions with the new rotation
+  UpdateDimensions();
 }
 
 RetainPtr<CPDF_Array> CPDF_Page::GetOrCreateAnnotsArray() {

--- a/core/fpdfapi/page/cpdf_page.h
+++ b/core/fpdfapi/page/cpdf_page.h
@@ -77,6 +77,13 @@ class CPDF_Page final : public IPDF_Page, public CPDF_PageObjectHolder {
   CFX_Matrix GetDisplayMatrix() const;
   int GetPageRotation() const;
 
+  // EmbedPDF extensions for rotation normalization
+  // Returns the rotation value from the page dictionary, ignoring any override.
+  int GetOriginalRotation() const;
+  // Sets a rotation override and recalculates dimensions.
+  // Pass -1 to clear the override.
+  void SetRotationOverride(int rotation);
+
   RetainPtr<CPDF_Array> GetOrCreateAnnotsArray();
   RetainPtr<CPDF_Array> GetMutableAnnotsArray();
   RetainPtr<const CPDF_Array> GetAnnotsArray() const;
@@ -111,6 +118,7 @@ class CPDF_Page final : public IPDF_Page, public CPDF_PageObjectHolder {
   std::unique_ptr<CPDF_PageImageCache> page_image_cache_;
   std::unique_ptr<RenderContextIface> render_context_;
   ObservedPtr<View> view_;
+  std::optional<int> rotation_override_;  // EmbedPDF: rotation normalization
 };
 
 #endif  // CORE_FPDFAPI_PAGE_CPDF_PAGE_H_

--- a/fpdfsdk/fpdf_view.cpp
+++ b/fpdfsdk/fpdf_view.cpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "build/build_config.h"
+#include "constants/page_object.h"
 #include "core/fpdfapi/page/cpdf_docpagedata.h"
 #include "core/fpdfapi/page/cpdf_occontext.h"
 #include "core/fpdfapi/page/cpdf_page.h"
@@ -1420,6 +1421,66 @@ EPDF_GetPageRotationByIndex(FPDF_DOCUMENT document, int page_index) {
     return -1;
   auto page = pdfium::MakeRetain<CPDF_Page>(pDoc, std::move(dict));
   return page->GetPageRotation();
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_GetPageSizeByIndexNormalized(FPDF_DOCUMENT document,
+                                   int page_index,
+                                   FS_SIZEF* size) {
+  if (!size)
+    return false;
+
+  auto* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc)
+    return false;
+
+  if (page_index < 0 || page_index >= FPDF_GetPageCount(document))
+    return false;
+
+  RetainPtr<CPDF_Dictionary> dict = pDoc->GetMutablePageDictionary(page_index);
+  if (!dict)
+    return false;
+
+  // Get bbox WITHOUT rotation adjustment
+  CFX_FloatRect mediabox = dict->GetRectFor(pdfium::page_object::kMediaBox);
+  if (mediabox.IsEmpty())
+    mediabox = CFX_FloatRect(0, 0, 612, 792);
+
+  CFX_FloatRect cropbox = dict->GetRectFor(pdfium::page_object::kCropBox);
+  CFX_FloatRect bbox = cropbox.IsEmpty() ? mediabox : cropbox;
+  bbox.Intersect(mediabox);
+
+  // Return original dimensions - NO swap for rotation
+  size->width = bbox.Width();
+  size->height = bbox.Height();
+  return true;
+}
+
+FPDF_EXPORT FPDF_PAGE FPDF_CALLCONV
+EPDF_LoadPageNormalized(FPDF_DOCUMENT document,
+                         int page_index,
+                         int* out_original_rotation) {
+  // Load page normally first
+  FPDF_PAGE page = FPDF_LoadPage(document, page_index);
+  if (!page)
+    return nullptr;
+
+  CPDF_Page* pPage = CPDFPageFromFPDFPage(page);
+  if (!pPage) {
+    FPDF_ClosePage(page);
+    return nullptr;
+  }
+
+  // Store original rotation before we override it
+  if (out_original_rotation) {
+    *out_original_rotation = pPage->GetOriginalRotation();
+  }
+
+  // Force rotation to 0 - this re-runs UpdateDimensions()
+  // Now page_size_ and page_matrix_ are calculated as if rotation=0
+  pPage->SetRotationOverride(0);
+
+  return page;
 }
 
 FPDF_EXPORT int FPDF_CALLCONV FPDF_GetPageSizeByIndex(FPDF_DOCUMENT document,

--- a/public/fpdfview.h
+++ b/public/fpdfview.h
@@ -874,7 +874,43 @@ FPDF_GetPageSizeByIndexF(FPDF_DOCUMENT document,
 //          The rotation in degrees (must be one of 0, 90, 180, 270).
 //          Returns -1 on error (document or page not found).
 FPDF_EXPORT int FPDF_CALLCONV
-EPDF_GetPageRotationByIndex(FPDF_DOCUMENT document, int page_index);                
+EPDF_GetPageRotationByIndex(FPDF_DOCUMENT document, int page_index);
+
+// Experimental EmbedPDF API.
+// Function: EPDF_GetPageSizeByIndexNormalized
+//          Get the ORIGINAL (non-rotated) size of the page at the given index.
+//          Unlike FPDF_GetPageSizeByIndexF, this does NOT swap width/height
+//          for 90/270 degree rotated pages. Does NOT load the page (lightweight).
+// Parameters:
+//          document    -   Handle to document. Returned by FPDF_LoadDocument().
+//          page_index  -   Page index, zero for the first page.
+//          size        -   Pointer to a FS_SIZEF to receive the page size (in points).
+// Return value:
+//          Non-zero for success. 0 for error.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_GetPageSizeByIndexNormalized(FPDF_DOCUMENT document,
+                                   int page_index,
+                                   FS_SIZEF* size);
+
+// Experimental EmbedPDF API.
+// Function: EPDF_LoadPageNormalized
+//          Load a page with rotation normalized to 0 degrees.
+//          All subsequent operations (GetPageWidth, annotations, text, rendering)
+//          will use normalized coordinates as if the page had no rotation.
+// Parameters:
+//          document            -   Handle to document.
+//          page_index          -   Page index, zero for the first page.
+//          out_original_rotation - Optional. Receives the original rotation (0-3).
+//                                  Can be NULL if not needed.
+// Return value:
+//          Handle to the loaded page, or NULL on failure.
+// Comments:
+//          The returned page must be closed with FPDF_ClosePage().
+//          Use out_original_rotation to know the actual page rotation for display.
+FPDF_EXPORT FPDF_PAGE FPDF_CALLCONV
+EPDF_LoadPageNormalized(FPDF_DOCUMENT document,
+                         int page_index,
+                         int* out_original_rotation);
 
 // Function: FPDF_GetPageSizeByIndex
 //          Get the size of the page at the given index.


### PR DESCRIPTION
Introduce rotation override support in CPDF_Page and expose experimental EmbedPDF APIs for normalized page sizes and loading.

Changes:
- Add optional<int> rotation_override_ to CPDF_Page and new methods GetOriginalRotation() and SetRotationOverride(int). GetPageRotation() now honors the override; SetRotationOverride(-1) clears it and triggers UpdateDimensions().
- Add EPDF_GetPageSizeByIndexNormalized to return the original (non-rotated) page size without loading the page and without swapping width/height for 90/270 rotations.
- Add EPDF_LoadPageNormalized to load a page, return its original rotation via an out param, and force the page rotation to 0 (recalculating dimensions) for normalized coordinates.
- Update public header to declare the new experimental APIs and add a constants include where needed.

These updates enable clients to treat pages as unrotated for layout/embedding scenarios while still retrieving the original rotation when required.