### PR TITLE
feat: document-sanitization EPDF_* exports (XMP, thumbnails, JavaScript)

### DIFF
--- a/fpdfsdk/fpdf_doc.cpp
+++ b/fpdfsdk/fpdf_doc.cpp
@@ -774,3 +774,62 @@ EPDF_GetMetaKeyName(FPDF_DOCUMENT document,
   }
   return 0;
 }
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveXMPMetadata(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc)
+    return false;
+
+  RetainPtr<CPDF_Dictionary> root = pDoc->GetMutableRoot();
+  if (!root)
+    return false;
+
+  // /Metadata is the catalog-level XMP stream (ISO 32000 §14.3.2). It is stored
+  // separately from /Info, so clearing Info via EPDF_SetMetaText() does not
+  // touch it. Removing the key drops the XMP from the document.
+  root->RemoveFor("Metadata");
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveEmbeddedThumbnails(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc)
+    return false;
+
+  const int count = pDoc->GetPageCount();
+  for (int i = 0; i < count; ++i) {
+    RetainPtr<CPDF_Dictionary> page = pDoc->GetMutablePageDictionary(i);
+    if (page)
+      page->RemoveFor("Thumb");
+  }
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveAllJavaScript(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc)
+    return false;
+
+  RetainPtr<CPDF_Dictionary> root = pDoc->GetMutableRoot();
+  if (!root)
+    return false;
+
+  // (1) Catalog /Names /JavaScript name tree (document-level scripts).
+  RetainPtr<CPDF_Dictionary> names = root->GetMutableDictFor("Names");
+  if (names)
+    names->RemoveFor("JavaScript");
+
+  // (2) /OpenAction, but only when it is a JavaScript action — a GoTo
+  // destination OpenAction is legitimate navigation and is left intact.
+  RetainPtr<const CPDF_Dictionary> open_action = root->GetDictFor("OpenAction");
+  if (open_action && open_action->GetNameFor("S") == "JavaScript")
+    root->RemoveFor("OpenAction");
+
+  // (3) Catalog-level /AA additional-actions (e.g. WillClose/WillPrint scripts).
+  root->RemoveFor("AA");
+
+  return true;
+}

--- a/public/fpdf_doc.h
+++ b/public/fpdf_doc.h
@@ -518,6 +518,40 @@ EPDF_GetMetaKeyName(FPDF_DOCUMENT document,
                     unsigned long buflen);
 
 // Experimental EmbedPDF Extension API.
+// Remove the document's XMP metadata stream (the catalog /Metadata entry).
+//
+//   document - handle to the document.
+//
+// XMP metadata (ISO 32000 §14.3.2) is stored separately from the Info
+// dictionary, so clearing Info via EPDF_SetMetaText() does not remove it. This
+// is the #1 redaction-sanitization miss: author/title/history can survive in
+// XMP. Returns true on success, including when no /Metadata is present.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveXMPMetadata(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
+// Remove every page's embedded thumbnail (the page /Thumb entry).
+//
+//   document - handle to the document.
+//
+// An embedded thumbnail can retain a pre-redaction image of the page. Returns
+// true on success, including when no thumbnails are present.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveEmbeddedThumbnails(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
+// Remove all document-level JavaScript from |document|: the catalog
+// /Names /JavaScript name tree, /OpenAction when it is a JavaScript action
+// (GoTo destinations are preserved), and the catalog /AA additional-actions
+// dictionary.
+//
+//   document - handle to the document.
+//
+// Returns true on success, including when no JavaScript is present.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveAllJavaScript(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
 // Create a new destination array of the form [page /XYZ left top zoom].
 //
 //   page     - handle to the destination page.


### PR DESCRIPTION
Implements the engine (C++) side of embedpdf/embed-pdf-viewer#673 — document-sanitization removal functions for redaction defensibility.

Adds three `EPDF_*` extension functions, mirroring the existing `EPDF_SetMetaText` style (declared in `public/fpdf_doc.h`, implemented in `fpdfsdk/`), so the WASM build's export generator picks them up automatically:

- **`EPDF_RemoveXMPMetadata(doc)`** — removes the catalog `/Metadata` (XMP) stream. XMP is stored separately from `/Info`, so clearing the Info dict leaves author/title/history in XMP; this removes it.
- **`EPDF_RemoveEmbeddedThumbnails(doc)`** — removes every page's `/Thumb` (can retain a pre-redaction page image).
- **`EPDF_RemoveAllJavaScript(doc)`** — removes the catalog `/Names /JavaScript` name tree, a JavaScript `/OpenAction` (a plain GoTo `/OpenAction` is preserved), and the catalog `/AA`.

Each uses the same `CPDFDocumentFromFPDFDocument` + `GetMutableRoot()` / `RemoveFor` (and `GetMutablePageDictionary` for thumbnails) patterns as the neighbouring extensions.

The TypeScript `sanitizeDocument(doc, options)` engine method that composes these (plus the existing `removeAttachment` loop and a non-incremental save), along with Node tests asserting each vector is removed while unrelated content is preserved, are in a companion PR on `embedpdf/embed-pdf-viewer` (which bumps the `pdfium-src` submodule to this commit once merged).

Open questions for maintainers are in #673 (granular exports vs. a single `EPDF_SanitizeDocument`; and treating hidden OCG layers as a separate follow-up).
