### PR TITLE
feat: EPDF_RemoveOptionalContentGroups — hidden optional-content layer removal (follow-up to #673)

### DIFF
--- a/fpdfsdk/fpdf_doc.cpp
+++ b/fpdfsdk/fpdf_doc.cpp
@@ -774,3 +774,62 @@ EPDF_GetMetaKeyName(FPDF_DOCUMENT document,
   }
   return 0;
 }
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveXMPMetadata(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc)
+    return false;
+
+  RetainPtr<CPDF_Dictionary> root = pDoc->GetMutableRoot();
+  if (!root)
+    return false;
+
+  // /Metadata is the catalog-level XMP stream (ISO 32000 §14.3.2). It is stored
+  // separately from /Info, so clearing Info via EPDF_SetMetaText() does not
+  // touch it. Removing the key drops the XMP from the document.
+  root->RemoveFor("Metadata");
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveEmbeddedThumbnails(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc)
+    return false;
+
+  const int count = pDoc->GetPageCount();
+  for (int i = 0; i < count; ++i) {
+    RetainPtr<CPDF_Dictionary> page = pDoc->GetMutablePageDictionary(i);
+    if (page)
+      page->RemoveFor("Thumb");
+  }
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveAllJavaScript(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc)
+    return false;
+
+  RetainPtr<CPDF_Dictionary> root = pDoc->GetMutableRoot();
+  if (!root)
+    return false;
+
+  // (1) Catalog /Names /JavaScript name tree (document-level scripts).
+  RetainPtr<CPDF_Dictionary> names = root->GetMutableDictFor("Names");
+  if (names)
+    names->RemoveFor("JavaScript");
+
+  // (2) /OpenAction, but only when it is a JavaScript action — a GoTo
+  // destination OpenAction is legitimate navigation and is left intact.
+  RetainPtr<const CPDF_Dictionary> open_action = root->GetDictFor("OpenAction");
+  if (open_action && open_action->GetNameFor("S") == "JavaScript")
+    root->RemoveFor("OpenAction");
+
+  // (3) Catalog-level /AA additional-actions (e.g. WillClose/WillPrint scripts).
+  root->RemoveFor("AA");
+
+  return true;
+}

--- a/fpdfsdk/fpdf_editpage.cpp
+++ b/fpdfsdk/fpdf_editpage.cpp
@@ -5,6 +5,7 @@
 // Original code copyright 2014 Foxit Software Inc. http://www.foxitsoftware.com
 
 #include "public/fpdf_edit.h"
+#include "public/fpdfview.h"
 
 #include <algorithm>
 #include <memory>
@@ -18,6 +19,7 @@
 #include "core/fpdfapi/page/cpdf_form.h"
 #include "core/fpdfapi/page/cpdf_formobject.h"
 #include "core/fpdfapi/page/cpdf_imageobject.h"
+#include "core/fpdfapi/page/cpdf_occontext.h"
 #include "core/fpdfapi/page/cpdf_page.h"
 #include "core/fpdfapi/page/cpdf_pageimagecache.h"
 #include "core/fpdfapi/page/cpdf_pageobject.h"
@@ -1216,5 +1218,57 @@ FPDFFormObj_RemoveObject(FPDF_PAGEOBJECT form_object,
 
   // Caller takes ownership of the removed page object
   removed_object.release();
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveOptionalContentGroups(FPDF_DOCUMENT document) {
+  CPDF_Document* pDoc = CPDFDocumentFromFPDFDocument(document);
+  if (!pDoc) {
+    return false;
+  }
+
+  // Visibility under the default (View) configuration: an object is "hidden"
+  // when an OFF optional-content group (or OCMD / VE expression) suppresses it.
+  auto oc = pdfium::MakeRetain<CPDF_OCContext>(pDoc, CPDF_OCContext::kView);
+
+  const int page_count = FPDF_GetPageCount(document);
+  for (int i = 0; i < page_count; ++i) {
+    // FPDF_LoadPage parses the page content, so the object list is populated.
+    FPDF_PAGE page = FPDF_LoadPage(document, i);
+    if (!page) {
+      continue;
+    }
+
+    CPDF_Page* pPage = CPDFPageFromFPDFPage(page);
+    if (IsPageObject(pPage)) {
+      // Collect hidden objects first, then remove, so the list is not mutated
+      // mid-iteration.
+      std::vector<CPDF_PageObject*> hidden;
+      const size_t count = pPage->GetPageObjectCount();
+      for (size_t k = 0; k < count; ++k) {
+        CPDF_PageObject* obj = pPage->GetPageObjectByIndex(k);
+        if (obj && !oc->CheckPageObjectVisible(obj)) {
+          hidden.push_back(obj);
+        }
+      }
+      if (!hidden.empty()) {
+        for (CPDF_PageObject* obj : hidden) {
+          // Dropping the returned unique_ptr frees the removed object.
+          pPage->RemovePageObject(obj);
+        }
+        CPDF_PageContentGenerator generator(pPage);
+        generator.GenerateContent();
+      }
+    }
+
+    FPDF_ClosePage(page);
+  }
+
+  // With the governed content removed, drop the optional-content machinery.
+  RetainPtr<CPDF_Dictionary> root = pDoc->GetMutableRoot();
+  if (root) {
+    root->RemoveFor("OCProperties");
+  }
   return true;
 }

--- a/public/fpdf_doc.h
+++ b/public/fpdf_doc.h
@@ -552,6 +552,19 @@ FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
 EPDF_RemoveAllJavaScript(FPDF_DOCUMENT document);
 
 // Experimental EmbedPDF Extension API.
+// Remove content governed by hidden optional-content groups (OCGs / layers):
+// for each page, drop page objects not visible under the default (View)
+// configuration, regenerate the page content, then remove the catalog
+// /OCProperties. This excises hidden-layer content rather than merely deleting
+// /OCProperties (which would make that content visible).
+//
+//   document - handle to the document.
+//
+// Returns true on success, including when no optional content is present.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveOptionalContentGroups(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
 // Create a new destination array of the form [page /XYZ left top zoom].
 //
 //   page     - handle to the destination page.

--- a/public/fpdf_doc.h
+++ b/public/fpdf_doc.h
@@ -518,6 +518,40 @@ EPDF_GetMetaKeyName(FPDF_DOCUMENT document,
                     unsigned long buflen);
 
 // Experimental EmbedPDF Extension API.
+// Remove the document's XMP metadata stream (the catalog /Metadata entry).
+//
+//   document - handle to the document.
+//
+// XMP metadata (ISO 32000 §14.3.2) is stored separately from the Info
+// dictionary, so clearing Info via EPDF_SetMetaText() does not remove it. This
+// is the #1 redaction-sanitization miss: author/title/history can survive in
+// XMP. Returns true on success, including when no /Metadata is present.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveXMPMetadata(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
+// Remove every page's embedded thumbnail (the page /Thumb entry).
+//
+//   document - handle to the document.
+//
+// An embedded thumbnail can retain a pre-redaction image of the page. Returns
+// true on success, including when no thumbnails are present.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveEmbeddedThumbnails(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
+// Remove all document-level JavaScript from |document|: the catalog
+// /Names /JavaScript name tree, /OpenAction when it is a JavaScript action
+// (GoTo destinations are preserved), and the catalog /AA additional-actions
+// dictionary.
+//
+//   document - handle to the document.
+//
+// Returns true on success, including when no JavaScript is present.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+EPDF_RemoveAllJavaScript(FPDF_DOCUMENT document);
+
+// Experimental EmbedPDF Extension API.
 // Create a new destination array of the form [page /XYZ left top zoom].
 //
 //   page     - handle to the destination page.


### PR DESCRIPTION
Follow-up to embedpdf/embed-pdf-viewer#673 — adds the fourth, harder sanitization vector: removing content hidden behind OFF optional-content groups (layers).

**Stacked on #27** (the XMP/JS/thumbnails exports). This branch includes #27's commit; the OCG-specific commit is `8b8a678`. Please land #27 first — I'll rebase this onto the merged base so it shows only the OCG change.

### `EPDF_RemoveOptionalContentGroups(doc)`

Hidden layers can't be sanitized by just deleting `/OCProperties` — that would make the hidden content *visible*. This excises the content instead: for each page it drops the page objects that are **not visible under the default (View) configuration** (using `CPDF_OCContext::CheckPageObjectVisible`, which resolves OCGs, OCMDs, and `/VE` visibility expressions), regenerates the page content, then removes the catalog `/OCProperties`. Implemented in `fpdfsdk/fpdf_editpage.cpp` (reuses `FPDF_LoadPage` for content parsing and `CPDF_PageContentGenerator` for regeneration), declared in `public/fpdf_doc.h`.

The TypeScript `optionalContentGroups` flag on `sanitizeDocument` and a test (`test-remove-ocg.mjs`: hidden-layer text removed via text extraction, `/OCProperties` gone, visible content preserved) are in the companion monorepo PR.

**Known scope / follow-ups** (noted for review): this covers page-level content marked by hidden OCGs. Content inside form XObjects with their own `/OC`, annotation `/OC`, and deeply nested cases may need additional handling or a rasterize-flatten fallback — happy to extend based on your preference.
