### PR TITLE
Keep read-purity content regeneration model

### DIFF
--- a/core/fpdfapi/edit/cpdf_pagecontentgenerator.cpp
+++ b/core/fpdfapi/edit/cpdf_pagecontentgenerator.cpp
@@ -372,17 +372,6 @@ CPDF_PageContentGenerator::CPDF_PageContentGenerator(
 CPDF_PageContentGenerator::~CPDF_PageContentGenerator() = default;
 
 void CPDF_PageContentGenerator::GenerateContent() {
-  std::optional<fxcrt::ostringstream> canonical_stream =
-      GenerateCanonicalPageStream();
-  if (canonical_stream.has_value()) {
-    ReplaceContentStreamsWithSingleStream(std::move(canonical_stream.value()));
-    // The canonical stream rewrites every content stream, so this is the full
-    // regeneration case where resource pruning is safe (see the
-    // regenerated_all_streams guard below).
-    UpdateResourcesDict(/*regenerated_all_streams=*/true);
-    return;
-  }
-
   std::map<int32_t, fxcrt::ostringstream> new_stream_data =
       GenerateModifiedStreams();
   // If no streams were regenerated or removed, nothing to do here.
@@ -426,51 +415,6 @@ int32_t CPDF_PageContentGenerator::CountExistingContentStreams() {
     return pdfium::checked_cast<int32_t>(arr->size());
   }
   return direct->IsStream() ? 1 : 0;
-}
-
-std::optional<fxcrt::ostringstream>
-CPDF_PageContentGenerator::GenerateCanonicalPageStream() {
-  if (!obj_holder_->IsPage()) {
-    return std::nullopt;
-  }
-
-  bool has_dirty_page_objects = false;
-  for (auto& pPageObj : page_objects_) {
-    // Must include dirty inactive page objects: replacing the whole content
-    // stream is how their original bytes disappear from this page.
-    if (pPageObj->IsDirty()) {
-      has_dirty_page_objects = true;
-      break;
-    }
-  }
-
-  if (!has_dirty_page_objects && !obj_holder_->HasDirtyStreams()) {
-    return std::nullopt;
-  }
-
-  obj_holder_->TakeDirtyStreams();
-
-  fxcrt::ostringstream buf;
-  buf << "q\n";
-  ProcessDefaultGraphics(&buf);
-
-  std::unique_ptr<const CPDF_ContentMarks> empty_content_marks =
-      std::make_unique<CPDF_ContentMarks>();
-  const CPDF_ContentMarks* content_marks = empty_content_marks.get();
-
-  for (auto& pPageObj : page_objects_) {
-    if (!pPageObj->IsActive()) {
-      pPageObj->SetDirty(false);
-      continue;
-    }
-
-    content_marks = ProcessContentMarks(&buf, pPageObj, content_marks);
-    ProcessPageObject(&buf, pPageObj);
-  }
-
-  FinishMarks(&buf, content_marks);
-  buf << "Q\n";
-  return buf;
 }
 
 std::map<int32_t, fxcrt::ostringstream>
@@ -601,13 +545,6 @@ CPDF_PageContentGenerator::GenerateModifiedStreams() {
   }
 
   return streams;
-}
-
-void CPDF_PageContentGenerator::ReplaceContentStreamsWithSingleStream(
-    fxcrt::ostringstream&& stream_data) {
-  default_graphics_name_ = GetOrCreateDefaultGraphics();
-  CPDF_PageContentManager page_content_manager(obj_holder_, document_);
-  page_content_manager.ReplaceWithSingleStream(&stream_data);
 }
 
 void CPDF_PageContentGenerator::UpdateContentStreams(

--- a/core/fpdfapi/edit/cpdf_pagecontentgenerator.h
+++ b/core/fpdfapi/edit/cpdf_pagecontentgenerator.h
@@ -10,7 +10,6 @@
 #include <stdint.h>
 
 #include <map>
-#include <optional>
 #include <vector>
 
 #include "core/fxcrt/bytestring.h"
@@ -70,19 +69,10 @@ class CPDF_PageContentGenerator {
   // streams are not touched.
   std::map<int32_t, fxcrt::ostringstream> GenerateModifiedStreams();
 
-  // For edited pages, regenerates all active page objects into one canonical
-  // content stream. PDF /Contents arrays are rendered as one continuous program,
-  // so keeping old split boundaries after edits can corrupt graphics-state
-  // handoff between streams.
-  std::optional<fxcrt::ostringstream> GenerateCanonicalPageStream();
-
   // For each entry in `new_stream_data`, adds the string buffer to the page's
   // content stream.
   void UpdateContentStreams(
       std::map<int32_t, fxcrt::ostringstream>&& new_stream_data);
-
-  void ReplaceContentStreamsWithSingleStream(
-      fxcrt::ostringstream&& stream_data);
 
   // Sets the stream index of all page objects with stream index ==
   // |CPDF_PageObject::kNoContentStream|. These are new objects that had not

--- a/core/fpdfapi/edit/cpdf_pagecontentmanager.cpp
+++ b/core/fpdfapi/edit/cpdf_pagecontentmanager.cpp
@@ -214,30 +214,6 @@ void CPDF_PageContentManager::UpdateStream(size_t stream_index,
   stream_reference->SetRef(document_, new_stream->GetObjNum());
 }
 
-void CPDF_PageContentManager::ReplaceWithSingleStream(
-    fxcrt::ostringstream* buf) {
-  if (is_form_xobject_) {
-    RetainPtr<CPDF_Stream> form_stream = GetContentsStream();
-    if (form_stream) {
-      form_stream->SetDataFromStringstreamAndRemoveFilter(buf);
-    }
-    return;
-  }
-
-  auto new_stream = document_->NewIndirect<CPDF_Stream>(buf);
-  RetainPtr<CPDF_Dictionary> page_dict = page_obj_holder_->GetMutableDict();
-  page_dict->SetNewFor<CPDF_Reference>("Contents", document_,
-                                       new_stream->GetObjNum());
-  contents_ = std::move(new_stream);
-  streams_to_remove_.clear();
-
-  for (const auto& obj : *page_obj_holder_) {
-    if (obj->IsActive()) {
-      obj->SetContentStream(0);
-    }
-  }
-}
-
 void CPDF_PageContentManager::ScheduleRemoveStreamByIndex(size_t stream_index) {
   streams_to_remove_.insert(stream_index);
 }

--- a/core/fpdfapi/edit/cpdf_pagecontentmanager.h
+++ b/core/fpdfapi/edit/cpdf_pagecontentmanager.h
@@ -33,11 +33,6 @@ class CPDF_PageContentManager {
   // is empty, then schedule the removal of the stream instead.
   void UpdateStream(size_t stream_index, fxcrt::ostringstream* buf);
 
-  // Replaces the page's entire Contents entry with one freshly generated stream
-  // and assigns all active page objects to content stream 0. For Form XObjects,
-  // this updates the existing form stream.
-  void ReplaceWithSingleStream(fxcrt::ostringstream* buf);
-
   bool HasStreamAtIndex(size_t stream_index);
 
  private:

--- a/fpdfsdk/fpdf_edit_embeddertest.cpp
+++ b/fpdfsdk/fpdf_edit_embeddertest.cpp
@@ -1735,19 +1735,23 @@ TEST_F(FPDFEditEmbedderTest, RemoveAllFromStream) {
     }
   }
 
-  // Generate contents should collapse edited split-stream page content into one
-  // canonical stream. The original streams share graphics state across stream
-  // boundaries, so preserving the old split after edits is unsafe.
+  // Generate contents should remove the empty stream and update the page
+  // objects' contents stream indexes.
   EXPECT_TRUE(FPDFPage_GenerateContent(page.get()));
 
-  // Content stream 0: all remaining page objects.
+  // Content stream 0: page objects 0-14.
+  // Content stream 1: page object 15.
   ASSERT_EQ(16, FPDFPage_CountObjects(page.get()));
   for (int i = 0; i < 16; i++) {
     FPDF_PAGEOBJECT page_object = FPDFPage_GetObject(page.get(), i);
     ASSERT_TRUE(page_object);
     CPDF_PageObject* cpdf_page_object =
         CPDFPageObjectFromFPDFPageObject(page_object);
-    EXPECT_EQ(0, cpdf_page_object->GetContentStream()) << i;
+    if (i < 15) {
+      EXPECT_EQ(0, cpdf_page_object->GetContentStream()) << i;
+    } else {
+      EXPECT_EQ(1, cpdf_page_object->GetContentStream()) << i;
+    }
   }
 
   static constexpr char kSplitStreamsRemovedStream1Png[] =
@@ -1761,21 +1765,26 @@ TEST_F(FPDFEditEmbedderTest, RemoveAllFromStream) {
   // Save the file
   EXPECT_TRUE(FPDF_SaveAsCopy(document(), this, 0));
 
-  // Re-open the file and check the page object count is still 16, and that the
-  // edited split streams were persisted as one canonical content stream.
+  // Re-open the file and check the page object count is still 16, and that
+  // content stream 1 was removed.
   ScopedSavedDoc saved_document = OpenScopedSavedDocument();
   ASSERT_TRUE(saved_document);
   ScopedSavedPage saved_page = LoadScopedSavedPage(0);
   ASSERT_TRUE(saved_page);
 
-  // Content stream 0: all remaining page objects.
+  // Content stream 0: page objects 0-14.
+  // Content stream 1: page object 15.
   EXPECT_EQ(16, FPDFPage_CountObjects(saved_page.get()));
   for (int i = 0; i < 16; i++) {
     FPDF_PAGEOBJECT page_object = FPDFPage_GetObject(saved_page.get(), i);
     ASSERT_TRUE(page_object);
     CPDF_PageObject* cpdf_page_object =
         CPDFPageObjectFromFPDFPageObject(page_object);
-    EXPECT_EQ(0, cpdf_page_object->GetContentStream()) << i;
+    if (i < 15) {
+      EXPECT_EQ(0, cpdf_page_object->GetContentStream()) << i;
+    } else {
+      EXPECT_EQ(1, cpdf_page_object->GetContentStream()) << i;
+    }
   }
 
   {


### PR DESCRIPTION
Revert the v2 split-stream canonicalization (936df8f5f) brought in by the read-purity merge. The two engines solve the same stream-boundary bug with incompatible contracts: canonicalization collapses all content into stream 0 and serializes only page objects — dropping ambient operators no page object owns (redact_inherited_colorspace's /C1 cs prolog) and minting a stream even when a page becomes empty (Bug1409 size bloat). read-purity's regenerate-all path preserves stream boundaries, append-only passes, and the pruning guard, and is what the v3 test matrix locks down.

Known follow-ups (pre-existing, not regressions): the regenerate-all block enumerates /Contents via GetObjectFor and so misses indirect arrays; the append-only exemption should be explicit; RealizeColorSpaceObject lacks CalRGB/Lab/Separation support.