### PR TITLE
Add geometry-only Skia stroke lib for redaction

### DIFF
--- a/core/fpdfapi/edit/BUILD.gn
+++ b/core/fpdfapi/edit/BUILD.gn
@@ -33,12 +33,16 @@ source_set("edit") {
   deps = [
     ":contentstream_write_utils",
     "../../../constants",
-    "../../../skia",
     "../../fxcrt",
     "../font",
     "../page",
     "../parser",
   ]
+  if (pdf_use_skia) {
+    deps += [ "../../../skia" ]
+  } else {
+    deps += [ "../../../skia:redaction_pathops" ]
+  }
   visibility = [ "../../../*" ]
 }
 

--- a/core/fpdfapi/edit/cpdf_path_redactor.cpp
+++ b/core/fpdfapi/edit/cpdf_path_redactor.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -18,15 +19,12 @@
 #include "core/fxge/cfx_fillrenderoptions.h"
 #include "core/fxge/cfx_graphstatedata.h"
 #include "third_party/skia/include/core/SkMatrix.h"
-#include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkPathBuilder.h"
-#include "third_party/skia/include/core/SkPathEffect.h"
-#include "third_party/skia/include/core/SkPathUtils.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkStrokeRec.h"
-#include "third_party/skia/include/effects/SkDashPathEffect.h"
 #include "third_party/skia/include/pathops/SkPathOps.h"
+#include "third_party/skia/src/utils/SkDashPathPriv.h"
 
 namespace {
 
@@ -279,15 +277,16 @@ std::optional<SkPath> BuildRedactionPath(const RedactRegion& region) {
         SkRect::MakeLTRB(rect.left, rect.bottom, rect.right, rect.top));
   }
 
-  SkPaint guard;
-  guard.setStyle(SkPaint::kStrokeAndFill_Style);
-  guard.setStrokeWidth(2.0f * kRedactionBoundaryGuard);
-  guard.setStrokeJoin(SkPaint::kMiter_Join);
-  guard.setStrokeMiter(4.0f);
-  bool is_fill = false;
-  SkPath expanded =
-      skpathutils::FillPathWithPaint(builder.detach(), guard, &is_fill);
-  if (!is_fill || !expanded.isFinite() || expanded.isEmpty()) {
+  SkStrokeRec guard(SkStrokeRec::kHairline_InitStyle);
+  guard.setStrokeStyle(2.0f * kRedactionBoundaryGuard,
+                       /*strokeAndFill=*/true);
+  guard.setStrokeParams(SkPaint::kButt_Cap, SkPaint::kMiter_Join, 4.0f);
+  SkPathBuilder expanded_builder;
+  if (!guard.applyToPath(&expanded_builder, builder.detach())) {
+    return std::nullopt;
+  }
+  SkPath expanded = expanded_builder.detach();
+  if (!expanded.isFinite() || expanded.isEmpty()) {
     return std::nullopt;
   }
   return expanded;
@@ -326,34 +325,35 @@ std::optional<SkPath> BuildStrokeOutline(const CPDF_PathObject& source,
   width = std::fabs(width);
   const bool is_hairline = width == 0.0f;
 
-  SkPaint paint;
-  paint.setStyle(SkPaint::kStroke_Style);
-  paint.setStrokeWidth(is_hairline ? kHairlineWidth : width);
-  paint.setStrokeMiter(std::max(1.0f, miter));
+  SkPaint::Cap cap = SkPaint::kButt_Cap;
   switch (graph_state.GetLineCap()) {
     case CFX_GraphStateData::LineCap::kButt:
-      paint.setStrokeCap(SkPaint::kButt_Cap);
+      cap = SkPaint::kButt_Cap;
       break;
     case CFX_GraphStateData::LineCap::kRound:
-      paint.setStrokeCap(SkPaint::kRound_Cap);
+      cap = SkPaint::kRound_Cap;
       break;
     case CFX_GraphStateData::LineCap::kSquare:
-      paint.setStrokeCap(SkPaint::kSquare_Cap);
+      cap = SkPaint::kSquare_Cap;
       break;
   }
+  SkPaint::Join join = SkPaint::kMiter_Join;
   switch (graph_state.GetLineJoin()) {
     case CFX_GraphStateData::LineJoin::kMiter:
-      paint.setStrokeJoin(SkPaint::kMiter_Join);
+      join = SkPaint::kMiter_Join;
       break;
     case CFX_GraphStateData::LineJoin::kRound:
-      paint.setStrokeJoin(SkPaint::kRound_Join);
+      join = SkPaint::kRound_Join;
       break;
     case CFX_GraphStateData::LineJoin::kBevel:
-      paint.setStrokeJoin(SkPaint::kBevel_Join);
+      join = SkPaint::kBevel_Join;
       break;
   }
 
-  sk_sp<SkPathEffect> dash_effect;
+  SkStrokeRec stroke_record(SkStrokeRec::kHairline_InitStyle);
+  stroke_record.setStrokeStyle(is_hairline ? kHairlineWidth : width);
+  stroke_record.setStrokeParams(cap, join, std::max(1.0f, miter));
+
   std::vector<float> dashes = graph_state.GetLineDashArray();
   if (!dashes.empty()) {
     bool has_positive_interval = false;
@@ -370,39 +370,58 @@ std::optional<SkPath> BuildStrokeOutline(const CPDF_PathObject& source,
       const std::vector<float> copy = dashes;
       dashes.insert(dashes.end(), copy.begin(), copy.end());
     }
-    dash_effect = SkDashPathEffect::Make(dashes, phase);
-    if (!dash_effect) {
+    if (!SkDashPath::ValidDashPath(phase, dashes)) {
       return std::nullopt;
     }
   }
 
   SkPath path_to_outline = local_path;
+  if (!dashes.empty()) {
+    float initial_dash_length = 0.0f;
+    size_t initial_dash_index = 0;
+    float interval_length = 0.0f;
+    float adjusted_phase = 0.0f;
+    SkDashPath::CalcDashParameters(phase, dashes, &initial_dash_length,
+                                   &initial_dash_index, &interval_length,
+                                   &adjusted_phase);
+
+    SkStrokeRec dash_stroke = stroke_record;
+    if (is_hairline) {
+      dash_stroke.setHairlineStyle();
+    }
+    SkPathBuilder dashed_builder;
+    if (SkDashPath::InternalFilter(
+            &dashed_builder, path_to_outline, &dash_stroke,
+            /*cullRect=*/nullptr, dashes, initial_dash_length,
+            static_cast<int32_t>(initial_dash_index), interval_length,
+            adjusted_phase)) {
+      path_to_outline = dashed_builder.detach();
+      stroke_record = dash_stroke;
+    } else if (is_hairline) {
+      return std::nullopt;
+    }
+  }
+
   if (is_hairline) {
     // A PDF zero-width stroke is a device-space hairline. Apply dashing in
     // the original user space, then transform the centerline and widen it in
     // page space. This avoids turning a scaled or sheared hairline into an
     // arbitrarily thick local-space stroke when it is persisted as a fill.
-    if (dash_effect) {
-      SkStrokeRec stroke_record(SkStrokeRec::kHairline_InitStyle);
-      SkPathBuilder dashed_builder;
-      if (!dash_effect->filterPath(&dashed_builder, path_to_outline,
-                                   &stroke_record)) {
-        return std::nullopt;
-      }
-      path_to_outline = dashed_builder.detach();
-    }
     path_to_outline = path_to_outline.makeTransform(local_to_page);
     if (!path_to_outline.isFinite()) {
       return std::nullopt;
     }
-  } else if (dash_effect) {
-    paint.setPathEffect(std::move(dash_effect));
+    stroke_record.setStrokeStyle(kHairlineWidth);
   }
 
-  bool is_fill = false;
-  SkPath outline =
-      skpathutils::FillPathWithPaint(path_to_outline, paint, &is_fill);
-  if (!is_fill || !outline.isFinite()) {
+  SkPathBuilder outline_builder;
+  if (stroke_record.applyToPath(&outline_builder, path_to_outline)) {
+    path_to_outline = outline_builder.detach();
+  } else if (!stroke_record.isFillStyle()) {
+    return std::nullopt;
+  }
+  SkPath outline = std::move(path_to_outline);
+  if (!outline.isFinite()) {
     return std::nullopt;
   }
   if (!is_hairline) {

--- a/patches/embedpdf-runtime/skia/geometry-only-stroke.patch
+++ b/patches/embedpdf-runtime/skia/geometry-only-stroke.patch
@@ -1,0 +1,188 @@
+diff --git a/gn/core.gni b/gn/core.gni
+index d77baca..90b2f0c 100644
+--- a/gn/core.gni
++++ b/gn/core.gni
+@@ -594,6 +594,7 @@ skia_core_sources = [
+   "$_src/core/SkStroke.cpp",
+   "$_src/core/SkStroke.h",
+   "$_src/core/SkStrokeRec.cpp",
++  "$_src/core/SkStrokeRec_paint.cpp",
+   "$_src/core/SkStrokerPriv.cpp",
+   "$_src/core/SkStrokerPriv.h",
+   "$_src/core/SkSurfacePriv.h",
+diff --git a/src/core/SkStrokeRec.cpp b/src/core/SkStrokeRec.cpp
+index 1f5bf98..9ea7fca 100644
+--- a/src/core/SkStrokeRec.cpp
++++ b/src/core/SkStrokeRec.cpp
+@@ -24,50 +24,6 @@ SkStrokeRec::SkStrokeRec(InitStyle s) {
+     fStrokeAndFill  = false;
+ }
+ 
+-SkStrokeRec::SkStrokeRec(const SkPaint& paint, SkScalar resScale) {
+-    this->init(paint, paint.getStyle(), resScale);
+-}
+-
+-SkStrokeRec::SkStrokeRec(const SkPaint& paint, SkPaint::Style styleOverride, SkScalar resScale) {
+-    this->init(paint, styleOverride, resScale);
+-}
+-
+-void SkStrokeRec::init(const SkPaint& paint, SkPaint::Style style, SkScalar resScale) {
+-    fResScale = resScale;
+-
+-    switch (style) {
+-        case SkPaint::kFill_Style:
+-            fWidth = kStrokeRec_FillStyleWidth;
+-            fStrokeAndFill = false;
+-            break;
+-        case SkPaint::kStroke_Style:
+-            fWidth = paint.getStrokeWidth();
+-            fStrokeAndFill = false;
+-            break;
+-        case SkPaint::kStrokeAndFill_Style:
+-            if (0 == paint.getStrokeWidth()) {
+-                // hairline+fill == fill
+-                fWidth = kStrokeRec_FillStyleWidth;
+-                fStrokeAndFill = false;
+-            } else {
+-                fWidth = paint.getStrokeWidth();
+-                fStrokeAndFill = true;
+-            }
+-            break;
+-        default:
+-            SkDEBUGFAIL("unknown paint style");
+-            // fall back on just fill
+-            fWidth = kStrokeRec_FillStyleWidth;
+-            fStrokeAndFill = false;
+-            break;
+-    }
+-
+-    // copy these from the paint, regardless of our "style"
+-    fMiterLimit = paint.getStrokeMiter();
+-    fCap        = paint.getStrokeCap();
+-    fJoin       = paint.getStrokeJoin();
+-}
+-
+ SkStrokeRec::Style SkStrokeRec::getStyle() const {
+     if (fWidth < 0) {
+         return kFill_Style;
+@@ -124,30 +80,10 @@ bool SkStrokeRec::applyToPath(SkPathBuilder* dst, const SkPath& src) const {
+     return true;
+ }
+ 
+-void SkStrokeRec::applyToPaint(SkPaint* paint) const {
+-    if (fWidth < 0) {  // fill
+-        paint->setStyle(SkPaint::kFill_Style);
+-        return;
+-    }
+-
+-    paint->setStyle(fStrokeAndFill ? SkPaint::kStrokeAndFill_Style : SkPaint::kStroke_Style);
+-    paint->setStrokeWidth(fWidth);
+-    paint->setStrokeMiter(fMiterLimit);
+-    paint->setStrokeCap((SkPaint::Cap)fCap);
+-    paint->setStrokeJoin((SkPaint::Join)fJoin);
+-}
+-
+ SkScalar SkStrokeRec::getInflationRadius() const {
+     return GetInflationRadius((SkPaint::Join)fJoin, fMiterLimit, (SkPaint::Cap)fCap, fWidth);
+ }
+ 
+-SkScalar SkStrokeRec::GetInflationRadius(const SkPaint& paint, SkPaint::Style style) {
+-    SkScalar width = SkPaint::kFill_Style == style ? -SK_Scalar1 : paint.getStrokeWidth();
+-    return GetInflationRadius(paint.getStrokeJoin(), paint.getStrokeMiter(), paint.getStrokeCap(),
+-                              width);
+-
+-}
+-
+ SkScalar SkStrokeRec::GetInflationRadius(SkPaint::Join join, SkScalar miterLimit, SkPaint::Cap cap,
+                                          SkScalar strokeWidth) {
+     if (strokeWidth < 0) {  // fill
+@@ -169,4 +105,3 @@ SkScalar SkStrokeRec::GetInflationRadius(SkPaint::Join join, SkScalar miterLimit
+     }
+     return strokeWidth/2 * multiplier;
+ }
+-
+diff --git a/src/core/SkStrokeRec_paint.cpp b/src/core/SkStrokeRec_paint.cpp
+new file mode 100644
+index 0000000..98857ac
+--- /dev/null
++++ b/src/core/SkStrokeRec_paint.cpp
+@@ -0,0 +1,79 @@
++/*
++ * Copyright 2012 Google Inc.
++ *
++ * Use of this source code is governed by a BSD-style license that can be
++ * found in the LICENSE file.
++ */
++
++#include "include/core/SkStrokeRec.h"
++
++#include "include/core/SkPaint.h"
++
++// Keep the SkPaint-dependent SkStrokeRec implementation separate from the
++// path-geometry implementation. This lets geometry-only clients use stroking
++// without linking SkPaint's rendering, shader, image-filter, and font graph.
++
++#define kStrokeRec_FillStyleWidth (-SK_Scalar1)
++
++SkStrokeRec::SkStrokeRec(const SkPaint& paint, SkScalar resScale) {
++    this->init(paint, paint.getStyle(), resScale);
++}
++
++SkStrokeRec::SkStrokeRec(const SkPaint& paint, SkPaint::Style styleOverride, SkScalar resScale) {
++    this->init(paint, styleOverride, resScale);
++}
++
++void SkStrokeRec::init(const SkPaint& paint, SkPaint::Style style, SkScalar resScale) {
++    fResScale = resScale;
++
++    switch (style) {
++        case SkPaint::kFill_Style:
++            fWidth = kStrokeRec_FillStyleWidth;
++            fStrokeAndFill = false;
++            break;
++        case SkPaint::kStroke_Style:
++            fWidth = paint.getStrokeWidth();
++            fStrokeAndFill = false;
++            break;
++        case SkPaint::kStrokeAndFill_Style:
++            if (0 == paint.getStrokeWidth()) {
++                // hairline+fill == fill
++                fWidth = kStrokeRec_FillStyleWidth;
++                fStrokeAndFill = false;
++            } else {
++                fWidth = paint.getStrokeWidth();
++                fStrokeAndFill = true;
++            }
++            break;
++        default:
++            SkDEBUGFAIL("unknown paint style");
++            // fall back on just fill
++            fWidth = kStrokeRec_FillStyleWidth;
++            fStrokeAndFill = false;
++            break;
++    }
++
++    // copy these from the paint, regardless of our "style"
++    fMiterLimit = paint.getStrokeMiter();
++    fCap = paint.getStrokeCap();
++    fJoin = paint.getStrokeJoin();
++}
++
++void SkStrokeRec::applyToPaint(SkPaint* paint) const {
++    if (fWidth < 0) {  // fill
++        paint->setStyle(SkPaint::kFill_Style);
++        return;
++    }
++
++    paint->setStyle(fStrokeAndFill ? SkPaint::kStrokeAndFill_Style : SkPaint::kStroke_Style);
++    paint->setStrokeWidth(fWidth);
++    paint->setStrokeMiter(fMiterLimit);
++    paint->setStrokeCap((SkPaint::Cap)fCap);
++    paint->setStrokeJoin((SkPaint::Join)fJoin);
++}
++
++SkScalar SkStrokeRec::GetInflationRadius(const SkPaint& paint, SkPaint::Style style) {
++    SkScalar width = SkPaint::kFill_Style == style ? -SK_Scalar1 : paint.getStrokeWidth();
++    return GetInflationRadius(
++            paint.getStrokeJoin(), paint.getStrokeMiter(), paint.getStrokeCap(), width);
++}

--- a/scripts/embedpdf-runtime/apply-patches.sh
+++ b/scripts/embedpdf-runtime/apply-patches.sh
@@ -69,6 +69,12 @@ copy_patch_file() {
 
 "$SOURCE_DIR/scripts/embedpdf-runtime/unapply-patches.sh"
 
+# The redaction-only Skia target uses stroking without SkPaint. Keep the
+# paint-dependent SkStrokeRec methods in a separate compilation unit so the
+# geometry archive does not inherit Skia's renderer/font dependency graph.
+apply_patch_file "$SOURCE_DIR/third_party/skia" \
+  "$PATCH_DIR/skia/geometry-only-stroke.patch"
+
 case "$TARGET" in
   wasm32)
     apply_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/wasm/build.patch"

--- a/scripts/embedpdf-runtime/unapply-patches.sh
+++ b/scripts/embedpdf-runtime/unapply-patches.sh
@@ -64,6 +64,8 @@ remove_copied_file "$PATCH_DIR/win/resources.rc" "$SOURCE_DIR/resources.rc"
 # Reverse every known runtime patch. Each reverse is independently optional so
 # this script is safe to run before any target build, regardless of which target
 # was built last.
+reverse_patch_file "$SOURCE_DIR/third_party/skia" \
+  "$PATCH_DIR/skia/geometry-only-stroke.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/win/build.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/mac/build.patch"
 reverse_patch_file "$SOURCE_DIR/build" "$PATCH_DIR/wasm/build.patch"

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -245,6 +245,98 @@ config("skia_library_config") {
   }
 }
 
+# The vector redactor needs SkPath, stroke expansion, dash effects, and
+# PathOps, but it does not use Skia as PDFium's rendering backend. Keep that
+# geometry-only dependency separate from :skia: the full target brings font
+# managers, FreeType, codecs, and GPU backends whose build contract is
+# intentionally gated by pdf_use_skia.
+#
+# A static library is deliberate: pathops is a cohesive collection of source
+# files, while the explicitly listed core files are its path/stroke dependency
+# closure. Keep this list narrow so adding an unrelated file to Skia core cannot
+# silently pull rendering or font dependencies into the runtime.
+static_library("redaction_pathops") {
+  visibility = [ "//core/fpdfapi/edit:*" ]
+  check_includes = false
+
+  public = [
+    "//third_party/skia/include/core/SkMatrix.h",
+    "//third_party/skia/include/core/SkPath.h",
+    "//third_party/skia/include/core/SkPathBuilder.h",
+    "//third_party/skia/include/core/SkRect.h",
+    "//third_party/skia/include/core/SkStrokeRec.h",
+    "//third_party/skia/include/pathops/SkPathOps.h",
+    "//third_party/skia/src/utils/SkDashPathPriv.h",
+  ]
+
+  sources = [
+    "//third_party/skia/src/base/SkArenaAlloc.cpp",
+    "//third_party/skia/src/base/SkBezierCurves.cpp",
+    "//third_party/skia/src/base/SkBuffer.cpp",
+    "//third_party/skia/src/base/SkContainers.cpp",
+    "//third_party/skia/src/base/SkCubics.cpp",
+    "//third_party/skia/src/base/SkFloatingPoint.cpp",
+    "//third_party/skia/src/base/SkMalloc.cpp",
+    "//third_party/skia/src/base/SkQuads.cpp",
+    "//third_party/skia/src/base/SkSafeMath.cpp",
+    "//third_party/skia/src/base/SkSemaphore.cpp",
+    "//third_party/skia/src/base/SkTDArray.cpp",
+    "//third_party/skia/src/base/SkThreadID.cpp",
+    "//third_party/skia/src/base/SkUTF.cpp",
+    "//third_party/skia/src/base/SkUtils.cpp",
+    "//third_party/skia/src/core/SkContourMeasure.cpp",
+    "//third_party/skia/src/core/SkCpu.cpp",
+    "//third_party/skia/src/core/SkCubicClipper.cpp",
+    "//third_party/skia/src/core/SkEdgeClipper.cpp",
+    "//third_party/skia/src/core/SkGeometry.cpp",
+    "//third_party/skia/src/core/SkIDChangeListener.cpp",
+    "//third_party/skia/src/core/SkLineClipper.cpp",
+    "//third_party/skia/src/core/SkM44.cpp",
+    "//third_party/skia/src/core/SkMatrix.cpp",
+    "//third_party/skia/src/core/SkMatrixInvert.cpp",
+    "//third_party/skia/src/core/SkOpts.cpp",
+    "//third_party/skia/src/core/SkPath.cpp",
+    "//third_party/skia/src/core/SkPathBuilder.cpp",
+    "//third_party/skia/src/core/SkPathData.cpp",
+    "//third_party/skia/src/core/SkPathDump.cpp",
+    "//third_party/skia/src/core/SkPathIter.cpp",
+    "//third_party/skia/src/core/SkPathMeasure.cpp",
+    "//third_party/skia/src/core/SkPathPriv.cpp",
+    "//third_party/skia/src/core/SkPathRaw.cpp",
+    "//third_party/skia/src/core/SkPathRawShapes.cpp",
+    "//third_party/skia/src/core/SkPath_pathdata.cpp",
+    "//third_party/skia/src/core/SkPoint.cpp",
+    "//third_party/skia/src/core/SkRRect.cpp",
+    "//third_party/skia/src/core/SkRect.cpp",
+    "//third_party/skia/src/core/SkString.cpp",
+    "//third_party/skia/src/core/SkStringUtils.cpp",
+    "//third_party/skia/src/core/SkStroke.cpp",
+    "//third_party/skia/src/core/SkStrokeRec.cpp",
+    "//third_party/skia/src/core/SkStrokerPriv.cpp",
+    "//third_party/skia/src/ports/SkMemory_malloc.cpp",
+    "//third_party/skia/src/utils/SkDashPath.cpp",
+    "//third_party/skia/src/utils/SkDashPathPriv.h",
+    "config/SkPdfiumUserConfig.h",
+    "ext/google_logging.cc",
+  ]
+  sources += skia_pathops_sources
+
+  if (!is_debug) {
+    configs -= [ "//build/config/compiler:default_optimization" ]
+    configs += [ "//build/config/compiler:optimize_max" ]
+  }
+
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [
+    ":skia_config",
+    ":skia_library_config",
+    "//build/config/compiler:no_chromium_code",
+  ]
+  public_configs = [ ":skia_config" ]
+
+  deps = [ ":skia_opts" ]
+}
+
 component("skia") {
   deps = []
 
@@ -523,7 +615,10 @@ skia_source_set("skia_opts") {
     configs += [ "//build/config/compiler:optimize_max" ]
   }
 
-  visibility = [ ":skia" ]
+  visibility = [
+    ":redaction_pathops",
+    ":skia",
+  ]
 }
 
 if (current_cpu == "x64") {


### PR DESCRIPTION
Introduce a geometry-only Skia static library (redaction_pathops) and use it for the PDF redaction codepath when pdf_use_skia is false. core/fpdfapi/edit/BUILD.gn now conditionally depends on full //third_party/skia when pdf_use_skia is enabled, otherwise on :skia:redaction_pathops. CPDF path redactor (cpdf_path_redactor.cpp) was ported to Skia geometry APIs (SkStrokeRec, SkDashPath::*, SkDashPathPriv) removing paint/path-effect dependencies. A patch (patches/embedpdf-runtime/skia/geometry-only-stroke.patch) splits paint-dependent SkStrokeRec bits into a separate compilation unit and updates GN files; scripts to apply/unapply runtime patches were updated accordingly. This reduces rendering/font dependency leakage into the redaction-only build.