### PR TITLE
Add full-fidelity text extraction API

### DIFF
--- a/fpdfsdk/fpdf_text.cpp
+++ b/fpdfsdk/fpdf_text.cpp
@@ -29,6 +29,7 @@
 #include "core/fxcrt/span.h"
 #include "core/fxcrt/span_util.h"
 #include "core/fxcrt/stl_util.h"
+#include "core/fxcrt/utf16.h"
 #include "fpdfsdk/cpdfsdk_helpers.h"
 
 namespace {
@@ -38,6 +39,10 @@ static_assert(offsetof(EPDF_CHAR_GEOMETRY, loose_box) == 0);
 static_assert(offsetof(EPDF_CHAR_GEOMETRY, tight_box) == 16);
 static_assert(offsetof(EPDF_CHAR_GEOMETRY, loose_quad) == 32);
 static_assert(offsetof(EPDF_CHAR_GEOMETRY, tight_quad) == 64);
+
+static_assert(sizeof(EPDF_CHAR_MAP_ANCHOR) == 8);
+static_assert(offsetof(EPDF_CHAR_MAP_ANCHOR, char_index) == 0);
+static_assert(offsetof(EPDF_CHAR_MAP_ANCHOR, text_offset) == 4);
 static_assert(offsetof(EPDF_CHAR_GEOMETRY, matrix) == 96);
 static_assert(offsetof(EPDF_CHAR_GEOMETRY, flags) == 120);
 
@@ -417,6 +422,76 @@ EPDFText_GetCharGeometry(FPDF_TEXTPAGE text_page,
 
   *geometry = result;
   return true;
+}
+
+FPDF_EXPORT int FPDF_CALLCONV EPDFText_GetTextFull(FPDF_TEXTPAGE text_page,
+                                                   unsigned short* buffer,
+                                                   int buffer_len) {
+  CPDF_TextPage* textpage = CPDFTextPageFromFPDFTextPage(text_page);
+  if (!textpage) {
+    return 0;
+  }
+  const int char_count = textpage->CountChars();
+  WideString str =
+      char_count > 0 ? textpage->GetPageText(0, char_count) : WideString();
+  // True UTF-16LE (surrogate pairs preserved), unlike FPDFText_GetText's
+  // ToUCS2LE which silently skips supplementary code points. Includes the
+  // two-byte terminator in the string data itself.
+  ByteString encoded = str.ToUTF16LE();
+  auto encoded_span =
+      fxcrt::reinterpret_span<const unsigned short>(encoded.span());
+  const int required = pdfium::checked_cast<int>(encoded_span.size());
+  if (buffer && buffer_len >= required) {
+    // SAFETY: required from caller. The two-call contract states that
+    // `buffer` must hold `buffer_len` UTF-16 units.
+    fxcrt::Copy(encoded_span, UNSAFE_BUFFERS(pdfium::span(
+                                  buffer, static_cast<size_t>(buffer_len))));
+  }
+  return required;
+}
+
+FPDF_EXPORT int FPDF_CALLCONV
+EPDFText_GetCharToTextMap(FPDF_TEXTPAGE text_page,
+                          EPDF_CHAR_MAP_ANCHOR* anchors,
+                          int anchors_len) {
+  CPDF_TextPage* textpage = CPDFTextPageFromFPDFTextPage(text_page);
+  if (!textpage) {
+    return -1;
+  }
+  // SAFETY: required from caller. The two-call contract states that
+  // `anchors` must hold `anchors_len` entries.
+  pdfium::span<EPDF_CHAR_MAP_ANCHOR> out =
+      anchors && anchors_len > 0
+          ? UNSAFE_BUFFERS(
+                pdfium::span(anchors, static_cast<size_t>(anchors_len)))
+          : pdfium::span<EPDF_CHAR_MAP_ANCHOR>();
+  const int char_count = textpage->CountChars();
+  int required = 0;
+  int offset = 0;
+  for (int i = 0; i < char_count; ++i) {
+    int units = 1;
+    if (textpage->TextIndexFromCharIndex(i) < 0) {
+      // Non-printing: occupies a character slot, contributes no text.
+      units = 0;
+    } else if (pdfium::IsSupplementary(
+                   static_cast<uint32_t>(
+                       textpage->GetCharInfo(static_cast<size_t>(i))
+                           .unicode()))) {
+      // Mirrors FX_UTF16Encode exactly: a supplementary code point becomes
+      // a surrogate pair in EPDFText_GetTextFull output; every other wchar
+      // (lone surrogate halves and out-of-range values included) is one
+      // truncated code unit.
+      units = 2;
+    }
+    if (units != 1) {
+      if (static_cast<size_t>(required) < out.size()) {
+        out[static_cast<size_t>(required)] = {i + 1, offset + units};
+      }
+      ++required;
+    }
+    offset += units;
+  }
+  return required;
 }
 
 FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFText_GetMatrix(FPDF_TEXTPAGE text_page,

--- a/fpdfsdk/fpdf_text_embeddertest.cpp
+++ b/fpdfsdk/fpdf_text_embeddertest.cpp
@@ -2460,6 +2460,102 @@ TEST_F(FPDFTextEmbedderTest, Bug384770169) {
   EXPECT_TRUE(saw_actual_text_piece);
 }
 
+TEST_F(FPDFTextEmbedderTest, EPDFTextGetTextFullMatchesGetTextOnBmpText) {
+  // bug_1139.pdf is BMP-only (31 characters, 30 text units — the first
+  // character is non-printing), so the full-fidelity extraction must be
+  // byte-identical to FPDFText_GetText, two-call contract included.
+  ASSERT_TRUE(OpenDocument("bug_1139.pdf"));
+  ScopedPage page = LoadScopedPage(0);
+  ASSERT_TRUE(page);
+
+  ScopedFPDFTextPage textpage(FPDFText_LoadPage(page.get()));
+  ASSERT_TRUE(textpage);
+
+  const int required = EPDFText_GetTextFull(textpage.get(), nullptr, 0);
+  ASSERT_EQ(31, required);  // 30 units + NUL
+
+  unsigned short full[64] = {};
+  ASSERT_EQ(required,
+            EPDFText_GetTextFull(textpage.get(), full, std::size(full)));
+
+  unsigned short legacy[64] = {};
+  ASSERT_EQ(required,
+            FPDFText_GetText(textpage.get(), 0,
+                             FPDFText_CountChars(textpage.get()), legacy));
+  EXPECT_THAT(pdfium::span(full).first(static_cast<size_t>(required)),
+              ElementsAreArray(
+                  pdfium::span(legacy).first(static_cast<size_t>(required))));
+
+  // A too-small buffer reports the requirement and writes nothing.
+  unsigned short tiny[4] = {0xABCD, 0xABCD, 0xABCD, 0xABCD};
+  ASSERT_EQ(required, EPDFText_GetTextFull(textpage.get(), tiny, 4));
+  EXPECT_EQ(0xABCD, tiny[0]);
+}
+
+TEST_F(FPDFTextEmbedderTest, EPDFTextGetCharToTextMapNonPrintingChar) {
+  // bug_1139.pdf: character 0 is non-printing, so the map is the single
+  // anchor {1, 0} — every later character shifts down by one text unit
+  // (the same +1 the searchex conversion tests pin).
+  ASSERT_TRUE(OpenDocument("bug_1139.pdf"));
+  ScopedPage page = LoadScopedPage(0);
+  ASSERT_TRUE(page);
+
+  ScopedFPDFTextPage textpage(FPDFText_LoadPage(page.get()));
+  ASSERT_TRUE(textpage);
+
+  ASSERT_EQ(1, EPDFText_GetCharToTextMap(textpage.get(), nullptr, 0));
+
+  EPDF_CHAR_MAP_ANCHOR anchors[4] = {};
+  ASSERT_EQ(1, EPDFText_GetCharToTextMap(textpage.get(), anchors,
+                                         std::size(anchors)));
+  EXPECT_EQ(1, anchors[0].char_index);
+  EXPECT_EQ(0, anchors[0].text_offset);
+}
+
+TEST_F(FPDFTextEmbedderTest, EPDFTextGetCharToTextMapIdentity) {
+  // Every character contributes exactly one text unit — zero anchors.
+  ASSERT_TRUE(OpenDocument("hello_world.pdf"));
+  ScopedPage page = LoadScopedPage(0);
+  ASSERT_TRUE(page);
+
+  ScopedFPDFTextPage textpage(FPDFText_LoadPage(page.get()));
+  ASSERT_TRUE(textpage);
+
+  EXPECT_EQ(0, EPDFText_GetCharToTextMap(textpage.get(), nullptr, 0));
+}
+
+TEST_F(FPDFTextEmbedderTest, EPDFTextAstralToUnicodeSurrogatePair) {
+  // A ToUnicode CMap mapping 'A' to <D83DDE00> stores one character-list
+  // entry PER SURROGATE HALF in lockstep with the text, so the page is
+  // identity-mapped (4 characters, 4 units) and the emoji survives
+  // extraction whole: D83D DE00 'B' '!'.
+  ASSERT_TRUE(OpenDocument("embedpdf_astral_tounicode.pdf"));
+  ScopedPage page = LoadScopedPage(0);
+  ASSERT_TRUE(page);
+
+  ScopedFPDFTextPage textpage(FPDFText_LoadPage(page.get()));
+  ASSERT_TRUE(textpage);
+
+  ASSERT_EQ(4, FPDFText_CountChars(textpage.get()));
+
+  const int required = EPDFText_GetTextFull(textpage.get(), nullptr, 0);
+  ASSERT_EQ(5, required);  // 4 units + NUL
+
+  unsigned short buffer[8] = {};
+  ASSERT_EQ(required,
+            EPDFText_GetTextFull(textpage.get(), buffer, std::size(buffer)));
+  static constexpr unsigned short kExpected[] = {0xD83D, 0xDE00, 0x0042,
+                                                 0x0021, 0};
+  EXPECT_THAT(pdfium::span(buffer).first(5u), ElementsAreArray(kExpected));
+
+  EXPECT_EQ(0, EPDFText_GetCharToTextMap(textpage.get(), nullptr, 0));
+}
+
+TEST_F(FPDFTextEmbedderTest, EPDFTextFullAndMapInvalidArgs) {
+  EXPECT_EQ(0, EPDFText_GetTextFull(nullptr, nullptr, 0));
+  EXPECT_EQ(-1, EPDFText_GetCharToTextMap(nullptr, nullptr, 0));
+}
+
 TEST_F(FPDFTextEmbedderTest, Bug420508260) {
   ASSERT_TRUE(OpenDocument("bug_420508260.pdf"));
   ScopedPage page = LoadScopedPage(0);

--- a/fpdfsdk/fpdf_view_c_api_test.c
+++ b/fpdfsdk/fpdf_view_c_api_test.c
@@ -45,6 +45,8 @@ fnptr g_c_api_test_fnptr = NULL;  // Extern, so can't know it doesn't change.
 int CheckPDFiumCApi() {
   // epdf_text.h
   CHK(EPDFText_GetCharGeometry);
+  CHK(EPDFText_GetCharToTextMap);
+  CHK(EPDFText_GetTextFull);
 
   // fpdf_annot.h
   CHK(FPDFAnnot_AddFileAttachment);

--- a/public/epdf_text.h
+++ b/public/epdf_text.h
@@ -50,6 +50,51 @@ EPDFText_GetCharGeometry(FPDF_TEXTPAGE text_page,
                          int index,
                          EPDF_CHAR_GEOMETRY* geometry);
 
+// Experimental EmbedPDF Extension API.
+// One anchor of the character->text mapping emitted by
+// EPDFText_GetCharToTextMap: from |char_index| onward (until the next
+// anchor) character boundary c maps to text offset
+// |text_offset| + (c - |char_index|).
+typedef struct EPDF_CHAR_MAP_ANCHOR_ {
+  int char_index;
+  int text_offset;
+} EPDF_CHAR_MAP_ANCHOR;
+
+// Experimental EmbedPDF Extension API.
+// Full-fidelity page text: the same extraction as
+// FPDFText_GetText(text_page, 0, FPDFText_CountChars(text_page), ...)
+// except encoded as true UTF-16LE — supplementary-plane characters are
+// emitted as surrogate pairs instead of being silently dropped by the
+// UCS-2 encoder. NUL-terminated.
+//
+// Two-call contract: call with a NULL |buffer| (or too-small
+// |buffer_len|) to learn the required size; the return value is ALWAYS
+// the number of UTF-16 units INCLUDING the terminator, and the buffer is
+// written only when |buffer| is non-null and |buffer_len| is at least
+// that large. Returns 0 for an invalid |text_page|.
+FPDF_EXPORT int FPDF_CALLCONV
+EPDFText_GetTextFull(FPDF_TEXTPAGE text_page,
+                     unsigned short* buffer,
+                     int buffer_len);
+
+// Experimental EmbedPDF Extension API.
+// The character->text mapping for EPDFText_GetTextFull output, as anchors
+// in ascending char_index order: one anchor at i+1 whenever character i
+// contributed something other than one UTF-16 unit (a non-printing
+// character contributes 0; a supplementary-plane character contributes
+// 2 — the same rule FX_UTF16Encode applies, so the map and the text can
+// never disagree). Text offsets are UTF-16 units of the
+// EPDFText_GetTextFull output. Zero anchors means identity: character
+// index == text offset everywhere.
+//
+// Two-call contract: the return value is ALWAYS the total anchor count;
+// entries are written up to |anchors_len| (a shorter buffer receives a
+// valid prefix). Returns -1 for an invalid |text_page|.
+FPDF_EXPORT int FPDF_CALLCONV
+EPDFText_GetCharToTextMap(FPDF_TEXTPAGE text_page,
+                          EPDF_CHAR_MAP_ANCHOR* anchors,
+                          int anchors_len);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/testing/resources/embedpdf_astral_tounicode.pdf
+++ b/testing/resources/embedpdf_astral_tounicode.pdf
@@ -1,0 +1,55 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding /ToUnicode 6 0 R >>
+endobj
+5 0 obj
+<< /Length 33 >>
+stream
+BT /F1 24 Tf 20 40 Td (AB!) Tj ET
+endstream
+endobj
+6 0 obj
+<< /Length 347 >>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+2 beginbfchar
+<41> <D83DDE00>
+<42> <0042>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000355 00000 n 
+0000000438 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+836
+%%EOF


### PR DESCRIPTION
Add experimental EPDF text APIs for full UTF-16LE extraction without silently dropping supplementary characters, plus a char-to-text anchor map that records non-printing and astral-character offsets. This updates the public headers, C API checks, and tests for BMP and surrogate-pair cases, including a new PDF resource used to verify astral ToUnicode behavior.